### PR TITLE
fix: 解决 FluentWindow 页面切换后重载清空内容的问题

### DIFF
--- a/RinUI/components/Navigation/NavigationItem.qml
+++ b/RinUI/components/Navigation/NavigationItem.qml
@@ -138,7 +138,7 @@ Item {
             }
             if (itemData.page && currentPage && !navigationItems.highlighted) {
                 // 记录上一次的索引
-                navigationView.safePush(itemData.page, true)
+                navigationView.safePush(itemData.page, false, true)
             }
         }
     }

--- a/RinUI/components/Navigation/NavigationSubItem.qml
+++ b/RinUI/components/Navigation/NavigationSubItem.qml
@@ -97,7 +97,7 @@ ItemDelegate {
     onClicked: {
         if (itemData.page && currentPage && !root.highlighted && !collapsed) {
             // 记录上一次的索引
-            navigationView.safePush(itemData.page)
+            navigationView.safePush(itemData.page, false, true)
         }
     }
 }

--- a/RinUI/components/Navigation/NavigationView.qml
+++ b/RinUI/components/Navigation/NavigationView.qml
@@ -19,6 +19,9 @@ RowLayout {
     property var lastPages: []  // 上个页面索引
     property int pushEnterFromY: height
     property var window: parent  // 窗口对象
+    
+    // 页面实例缓存
+    property var pageCache: ({})
 
     signal pageChanged()  // 页面切换信号
 
@@ -191,7 +194,7 @@ RowLayout {
         safePush(page, reload)
     }
 
-    function safePush(page, reload) {
+    function safePush(page, reload, fromNavigation) {
         // 无效检测
         if (!(typeof page === "object" || typeof page === "string" || page instanceof Component)) {
             console.error("Invalid page:", page)
@@ -204,28 +207,100 @@ RowLayout {
             return
         }
 
-        navigationBar.lastPages.push(navigationBar.currentPage)  // 记录当前页面
-        navigationBar.lastPages = navigationBar.lastPages  // refresh
-        navigationBar.currentPage = page.toString()
-        pageChanged()
-
         if (page instanceof Component) {
-            // let obj = page.createObject(stackView)
+            // 对于Component类型，直接使用
+            navigationBar.lastPages.push(navigationBar.currentPage)  // 记录当前页面
+            navigationBar.lastPages = navigationBar.lastPages  // refresh
+            navigationBar.currentPage = page.toString()
+            pageChanged()
             stackView.push(page)
 
         } else if (typeof page === "object" || typeof page === "string" ) {
-            let component = Qt.createComponent(page)  // 页面转控件
+            let pageKey = page.toString()
+            
+            // 检查缓存中是否已有该页面实例
+            if (!pageCache[pageKey] || reload) {
+                let component = Qt.createComponent(page)  // 页面转控件
 
-            if (component.status === Component.Ready) {
-                console.log("Depth:", stackView.depth)
-                stackView.push(component)
-
-            } else if (component.status === Component.Error) {
-                console.error("Failed to load:", page, component.errorString())
-                stackView.push("ErrorPage.qml", {
-                    errorMessage: component.errorString(),  // 传参
-                    page: page,
-                })
+                if (component.status === Component.Ready) {
+                    // 创建页面实例并缓存
+                    let pageInstance = component.createObject(null)
+                    pageCache[pageKey] = pageInstance
+                    console.log("Created and cached page:", pageKey)
+                } else if (component.status === Component.Error) {
+                    console.error("Failed to load:", page, component.errorString())
+                    navigationBar.lastPages.push(navigationBar.currentPage)  // 记录当前页面
+                    navigationBar.lastPages = navigationBar.lastPages  // refresh
+                    navigationBar.currentPage = page.toString()
+                    pageChanged()
+                    stackView.push("ErrorPage.qml", {
+                        errorMessage: component.errorString(),  // 传参
+                        page: page,
+                    })
+                    return
+                }
+            }
+            
+            // 使用缓存的页面实例
+            if (pageCache[pageKey]) {
+                console.log("Using cached page:", pageKey, "Depth:", stackView.depth)
+                
+                // 对于侧边栏导航，始终推送页面以保持一致的动画效果
+                // 如果页面已在栈中，创建一个新的实例来避免StackView限制
+                let pageInstance = pageCache[pageKey]
+                let isInStack = false
+                for (let i = 0; i < stackView.depth; i++) {
+                    if (stackView.get(i) === pageInstance) {
+                        isInStack = true
+                        break
+                    }
+                }
+                
+                if (isInStack && fromNavigation) {
+                    // 如果是侧边栏导航且页面已在栈中，先从栈中移除该实例，然后重新推送
+                    console.log("Removing and re-pushing cached page:", pageKey)
+                    
+                    // 找到页面在栈中的位置并移除
+                    let targetIndex = -1
+                    for (let i = 0; i < stackView.depth; i++) {
+                        if (stackView.get(i) === pageInstance) {
+                            targetIndex = i
+                            break
+                        }
+                    }
+                    
+                    if (targetIndex >= 0) {
+                        // 移除该页面实例（但不销毁，因为它在缓存中）
+                        let tempItems = []
+                        for (let i = targetIndex + 1; i < stackView.depth; i++) {
+                            tempItems.push(stackView.get(i))
+                        }
+                        
+                        // 弹出到目标页面之前
+                        while (stackView.depth > targetIndex) {
+                            stackView.pop(null, StackView.Immediate)
+                        }
+                        
+                        // 现在可以安全推送页面
+                        navigationBar.lastPages.push(navigationBar.currentPage)
+                        navigationBar.lastPages = navigationBar.lastPages
+                        navigationBar.currentPage = pageKey
+                        pageChanged()
+                        stackView.push(pageInstance)
+                    }
+                } else if (!isInStack) {
+                    // 页面不在栈中，使用缓存实例
+                    navigationBar.lastPages.push(navigationBar.currentPage)
+                    navigationBar.lastPages = navigationBar.lastPages
+                    navigationBar.currentPage = pageKey
+                    pageChanged()
+                    stackView.push(pageInstance)
+                } else {
+                    // 页面已在栈中且不是侧边栏导航，只更新状态
+                    console.log("Page instance already in stack, updating state only:", pageKey)
+                    navigationBar.currentPage = pageKey
+                    pageChanged()
+                }
             }
         }
     }


### PR DESCRIPTION
修复了在 FluentWindow 中通过侧边栏切换页面时，页面会被重新创建导致编辑内容丢失的问题。

之前的逻辑是每次导航都 `new` 一个新的页面实例，导致在页面 A 编辑后，切换到 B 再切回 A 时，会看到一个空白的 A 页面。本次修改调整为优先查找并复用已存在的页面实例，确保了页面状态在切换后得以保持一致。

Fixes: https://github.com/RinLit-233-shiroko/Rin-UI/issues/32