### PR TITLE
fix: 窗口最大化时尺寸位置计算错误

### DIFF
--- a/RinUI/core/window.py
+++ b/RinUI/core/window.py
@@ -7,7 +7,7 @@ from ctypes import wintypes
 
 import win32con
 from PySide6.QtQuick import QQuickWindow
-from win32gui import ReleaseCapture, GetWindowPlacement, ShowWindow
+from win32gui import ReleaseCapture, GetWindowPlacement, ShowWindow, SetWindowPlacement
 from win32con import SW_MAXIMIZE, SW_RESTORE
 from win32api import SendMessage
 
@@ -106,7 +106,30 @@ class WinEventManager(QObject):
             if current_state == SW_MAXIMIZE:
                 ShowWindow(hwnd, SW_RESTORE)
             else:
-                ShowWindow(hwnd, SW_MAXIMIZE)
+                # 获取当前窗口矩形
+                current_rect = wintypes.RECT()
+                user32.GetWindowRect(hwnd, ctypes.byref(current_rect))
+                # 获取显示器工作区域
+                monitor = user32.MonitorFromWindow(hwnd, 2)  # MONITOR_DEFAULTTONEAREST
+                monitor_info = MONITORINFO()
+                monitor_info.cbSize = ctypes.sizeof(MONITORINFO)
+                user32.GetMonitorInfoW(monitor, ctypes.byref(monitor_info))
+                work_area = monitor_info.rcWork
+                # 计算目标位置和尺寸(工作区域)
+                target_x = work_area.left
+                target_y = work_area.top
+                target_width = work_area.right - work_area.left
+                target_height = work_area.bottom - work_area.top
+                user32.SetWindowPos(
+                    hwnd,
+                    0,  # hWndInsertAfter
+                    target_x, target_y,
+                    target_width, target_height,
+                    0x0040  # SWP_FRAMECHANGED
+                )
+                # 更新窗口状态
+                placement[1] = SW_MAXIMIZE
+                SetWindowPlacement(hwnd, placement)
 
         except Exception as e:
             print(f"Error toggling window state: {e}")
@@ -224,8 +247,8 @@ class WinEventFilter(QAbstractNativeEventFilter):
                     # 最大化位置和大小
                     minmax_info.ptMaxPosition.x = monitor_info.rcWork.left - monitor_info.rcMonitor.left
                     minmax_info.ptMaxPosition.y = monitor_info.rcWork.top - monitor_info.rcMonitor.top
-                    minmax_info.ptMaxSize.x = monitor_info.rcWork.right - monitor_info.rcMonitor.left
-                    minmax_info.ptMaxSize.y = monitor_info.rcWork.bottom - monitor_info.rcMonitor.top
+                    minmax_info.ptMaxSize.x = monitor_info.rcWork.right - monitor_info.rcWork.left
+                    minmax_info.ptMaxSize.y = monitor_info.rcWork.bottom - monitor_info.rcWork.top
 
 
                     def get_window_int_property(window, name, default):


### PR DESCRIPTION
重写 `maximizeWindow` 函数，从依赖系统默认行为改为精确控制:
使用 `windows api` 和 `SetWindowPos`来控制窗口最大化位置

理论上还修复任务栏在左/右侧时窗口最大化会被覆盖的问题

---
图片:
前:<img width="266" height="119" alt="image" src="https://github.com/user-attachments/assets/93388e58-c441-46f9-ad6e-dc1665b06e95" /> 后: 
<img width="277" height="157" alt="image" src="https://github.com/user-attachments/assets/acc43cb7-e9a7-42a9-ba2b-1f85dc0e7eda" />

~还要磨细节的话,就是最大化的时候把圆角效果关了(~