### PR TITLE
禁止TextField的clearButton获取焦点

### DIFF
--- a/RinUI/components/Text/TextField.qml
+++ b/RinUI/components/Text/TextField.qml
@@ -94,6 +94,7 @@ TextField {
         anchors.verticalCenter: parent.verticalCenter
         implicitWidth: 24
         implicitHeight: 24
+        focusPolicy: Qt.NoFocus
         flat: true
         highlighted: true
         visible: clearEnabled && root.text && root.text.length > 0 && root.activeFocus


### PR DESCRIPTION
避免TextField的清空按钮获取焦点导致TextField失去焦点，从而导致某些情况下清空按钮瞬间消失无法点击  