### PR TITLE
feat(windows): 增加 Windows 11 Snap Layout 支持

### DIFF
--- a/RinUI/components/DateAndTime/CalendarDatePicker.qml
+++ b/RinUI/components/DateAndTime/CalendarDatePicker.qml
@@ -42,7 +42,7 @@ Button {
     }
 
     text: root.selectedDate ? root.fmt(root.selectedDate) : root.placeholderText
-    onClicked: { pickerPopup.open() }
+    onClicked: { pickerPopup.visible ? pickerPopup.close() : pickerPopup.open() }
 
 
     contentItem: RowLayout {

--- a/RinUI/components/Navigation/NavigationBar.qml
+++ b/RinUI/components/Navigation/NavigationBar.qml
@@ -25,6 +25,7 @@ Item {
     property int macControlLeftMargin: 20
     property int macDragGap: 12
     property int macNativeControlExtraInset: useNativeMacControls ? 18 : 0
+    property int macNativeVisualInset: useNativeMacControls ? 8 : 0
     property int titleBarHeight: window && window.titleBarHeight !== undefined
         ? window.titleBarHeight
         : Theme.currentTheme.appearance.windowTitleBarHeight
@@ -219,7 +220,7 @@ Item {
             ? navigationBar.window.titleBarHost
             : navigationBar
         anchors.left: parent.left
-        anchors.leftMargin: navigationBar.macTitleSafeInset
+        anchors.leftMargin: navigationBar.macTitleSafeInset + navigationBar.macNativeVisualInset
         anchors.verticalCenter: parent.verticalCenter
         height: titleBarHeight
         spacing: 16
@@ -232,8 +233,9 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
             icon.name: "ic_fluent_arrow_left_20_regular"
             onClicked: navigationView.safePop()
-            width: 40
-            height: 40
+            property int controlSize: Math.max(32, Math.min(40, title.height - 4))
+            width: controlSize
+            height: controlSize
             size: 16
             enabled: navigationView.lastPages.length > 0
 

--- a/RinUI/core/launcher.py
+++ b/RinUI/core/launcher.py
@@ -108,8 +108,8 @@ class RinUIWindow:
 
         from .window import WinEventFilter, WinEventManager
 
-        self.win_event_filter = WinEventFilter(self.windows)
         self.win_event_manager = WinEventManager()
+        self.win_event_filter = WinEventFilter(self.windows, self.win_event_manager)
 
         app_instance = QApplication.instance()
         app_instance.installNativeEventFilter(self.win_event_filter)

--- a/RinUI/core/launcher.py
+++ b/RinUI/core/launcher.py
@@ -169,7 +169,8 @@ class RinUIWindow:
             # Hide the system title visuals and keep traffic lights in place.
             ns_window.setTitleVisibility_(self._mac_appkit.NSWindowTitleHidden)
             ns_window.setTitlebarAppearsTransparent_(True)
-            ns_window.setMovableByWindowBackground_(False)
+            # Allow dragging from custom title/content background areas.
+            ns_window.setMovableByWindowBackground_(True)
             style_mask = int(ns_window.styleMask()) | int(
                 self._mac_appkit.NSWindowStyleMaskFullSizeContentView
             )

--- a/RinUI/core/window.py
+++ b/RinUI/core/window.py
@@ -3,7 +3,13 @@ import platform
 from ctypes import wintypes
 
 import win32con
-from PySide6.QtCore import QAbstractNativeEventFilter, QByteArray, QObject, Slot
+from PySide6.QtCore import (
+    QAbstractNativeEventFilter,
+    QByteArray,
+    QObject,
+    Signal,
+    Slot,
+)
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtQuick import QQuickWindow
 from win32api import GetSystemMetrics, MonitorFromWindow, SendMessage
@@ -82,11 +88,24 @@ user32 = ctypes.windll.user32
 # 定义必要的 Windows 常量
 WM_NCCALCSIZE = 0x0083
 WM_NCHITTEST = 0x0084
+WM_NCMOUSEMOVE = 0x00A0
+WM_NCLBUTTONDOWN = 0x00A1
+WM_NCLBUTTONUP = 0x00A2
+WM_NCMOUSELEAVE = 0x02A2
 WM_SYSCOMMAND = 0x0112
 WM_GETMINMAXINFO = 0x0024
+WM_SIZE = 0x0005
+
+WVR_REDRAW = 0x0300
+
+HTCAPTION = 2
+HTMAXBUTTON = 9
 
 WS_CAPTION = 0x00C00000
 WS_THICKFRAME = 0x00040000
+WS_SYSMENU = 0x00080000
+WS_MAXIMIZEBOX = 0x00010000
+WS_MINIMIZEBOX = 0x00020000
 
 SC_MINIMIZE = 0xF020
 SC_MAXIMIZE = 0xF030
@@ -100,6 +119,15 @@ class MINMAXINFO(ctypes.Structure):
         ("ptMaxPosition", wintypes.POINT),
         ("ptMinTrackSize", wintypes.POINT),
         ("ptMaxTrackSize", wintypes.POINT),
+    ]
+
+
+class TRACKMOUSEEVENT(ctypes.Structure):
+    _fields_ = [
+        ("cbSize", wintypes.DWORD),
+        ("dwFlags", wintypes.DWORD),
+        ("hwndTrack", wintypes.HWND),
+        ("dwHoverTime", wintypes.DWORD),
     ]
 
 
@@ -144,10 +172,15 @@ def get_resize_border_thickness(hwnd: wintypes.HWND, horizontal=True) -> int:
 
 
 class WinEventManager(QObject):
+    # Sync non-client maximize-button hover/press state back to QML.
+    maximizeBtnHovered = Signal(int)
+    maximizeBtnLeave = Signal(int)
+    maximizeBtnPressed = Signal(int)
+    maximizeBtnReleased = Signal(int)
+
     @Slot(QObject, result=int)
     def getWindowId(self, window):
         """获取窗口的句柄"""
-        print(f"GetWindowId: {window.winId()}")
         return int(window.winId())
 
     @Slot(int)
@@ -189,11 +222,15 @@ class WinEventManager(QObject):
 
 
 class WinEventFilter(QAbstractNativeEventFilter):
-    def __init__(self, windows: list):
+    # Logical px, converted to physical px with devicePixelRatio.
+    CAPTION_BTN_WIDTH = 48
+    TITLE_BAR_LEFT_INTERACTIVE_WIDTH = 48
+
+    def __init__(self, windows: list, win_event_manager: WinEventManager = None):
         super().__init__()
         self.windows = windows  # 接受多个窗口
         self.hwnds = {}  # 用于存储每个窗口的 hwnd
-        self.resize_border = 8
+        self.win_event_manager = win_event_manager
 
         for window in self.windows:
             # 使用lambda创建闭包来捕获特定的窗口对象
@@ -219,13 +256,87 @@ class WinEventFilter(QAbstractNativeEventFilter):
             return
 
         style = user32.GetWindowLongPtrW(hwnd, -16)  # GWL_STYLE
-        style |= WS_CAPTION | WS_THICKFRAME
+        style |= (
+            WS_CAPTION | WS_THICKFRAME | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX
+        )
         user32.SetWindowLongPtrW(hwnd, -16, style)  # GWL_STYLE
+
+        # Keep DWM shadow without letting it fully own non-client hit-testing.
+        margins = (ctypes.c_int * 4)(0, 0, 0, 1)
+        ctypes.windll.dwmapi.DwmExtendFrameIntoClientArea(hwnd, ctypes.byref(margins))
 
         # 重绘
         user32.SetWindowPos(
             hwnd, 0, 0, 0, 0, 0, 0x0002 | 0x0001 | 0x0040
         )  # SWP_NOMOVE | SWP_NOSIZE | SWP_FRAMECHANGED
+
+    def _is_in_maximize_btn(
+        self, window: QQuickWindow, hwnd: int, screen_x: int, screen_y: int
+    ) -> bool:
+        max_enabled = window.property("maximizeEnabled")
+        if max_enabled is not None and not max_enabled:
+            return False
+
+        max_visible = window.property("maximizeVisible")
+        if max_visible is not None and not max_visible:
+            return False
+
+        rect = wintypes.RECT()
+        user32.GetWindowRect(hwnd, ctypes.byref(rect))
+
+        screen = window.screen()
+        dp_ratio = screen.devicePixelRatio() if screen else 1.0
+
+        btn_w = int(self.CAPTION_BTN_WIDTH * dp_ratio)
+        title_h = (
+            int(window.property("titleBarHeight") * dp_ratio)
+            if window.property("titleBarHeight")
+            else int(48 * dp_ratio)
+        )
+
+        close_visible = window.property("closeVisible")
+        close_visible = True if close_visible is None else bool(close_visible)
+
+        btn_right = rect.right - (btn_w if close_visible else 0)
+        btn_left = btn_right - btn_w
+        btn_top = rect.top
+        btn_bottom = btn_top + title_h
+
+        return btn_left <= screen_x < btn_right and btn_top <= screen_y < btn_bottom
+
+    def _is_in_title_bar_drag_region(
+        self, window: QQuickWindow, hwnd: int, screen_x: int, screen_y: int
+    ) -> bool:
+        rect = wintypes.RECT()
+        user32.GetWindowRect(hwnd, ctypes.byref(rect))
+
+        screen = window.screen()
+        dp_ratio = screen.devicePixelRatio() if screen else 1.0
+        title_h = (
+            int(window.property("titleBarHeight") * dp_ratio)
+            if window.property("titleBarHeight")
+            else int(48 * dp_ratio)
+        )
+        btn_w = int(self.CAPTION_BTN_WIDTH * dp_ratio)
+
+        if not (
+            rect.left <= screen_x < rect.right
+            and rect.top <= screen_y < rect.top + title_h
+        ):
+            return False
+
+        left_interactive_width = int(self.TITLE_BAR_LEFT_INTERACTIVE_WIDTH * dp_ratio)
+        if screen_x < rect.left + left_interactive_width:
+            return False
+
+        button_count = 0
+        for prop_name in ("closeVisible", "maximizeVisible", "minimizeVisible"):
+            value = window.property(prop_name)
+            if value is None or bool(value):
+                button_count += 1
+
+        control_area_left = rect.right - button_count * btn_w
+        return rect.left + left_interactive_width <= screen_x < control_area_left
 
     def nativeEventFilter(self, event_type: QByteArray, message):
         if event_type != b"windows_generic_MSG":
@@ -252,12 +363,27 @@ class WinEventFilter(QAbstractNativeEventFilter):
         # 遍历每个窗口，检查哪个窗口收到了消息
         for window in self.windows:
             hwnd_window = self.hwnds.get(window)
+
+            # Window handle may change after native recreation; refresh cached hwnd.
+            if hwnd_window != hwnd and window.isVisible():
+                try:
+                    current_hwnd = int(window.winId())
+                except Exception:
+                    current_hwnd = None
+                if current_hwnd and current_hwnd == hwnd and current_hwnd != hwnd_window:
+                    self.hwnds[window] = current_hwnd
+                    self.set_window_styles(window)
+                    hwnd_window = current_hwnd
+
             if hwnd_window != hwnd:
                 continue
 
             if message_id == WM_NCHITTEST:
                 x = ctypes.c_short(l_param & 0xFFFF).value
                 y = ctypes.c_short((l_param >> 16) & 0xFFFF).value
+
+                if self._is_in_maximize_btn(window, hwnd_window, x, y):
+                    return True, HTMAXBUTTON
 
                 rect = wintypes.RECT()
                 user32.GetWindowRect(hwnd_window, ctypes.byref(rect))
@@ -267,7 +393,7 @@ class WinEventFilter(QAbstractNativeEventFilter):
                     rect.right,
                     rect.bottom,
                 )
-                border = self.resize_border
+                border = get_resize_border_thickness(hwnd_window)
 
                 if left <= x < left + border:
                     if top <= y < top + border:
@@ -286,64 +412,107 @@ class WinEventFilter(QAbstractNativeEventFilter):
                 if bottom - border <= y < bottom:
                     return True, 15  # HTBOTTOM
 
+                if self._is_in_title_bar_drag_region(window, hwnd_window, x, y):
+                    return True, HTCAPTION
+
                 # 其他区域不处理
                 return False, 0
 
+            if message_id == WM_NCMOUSEMOVE:
+                if w_param == HTMAXBUTTON and self.win_event_manager:
+                    self.win_event_manager.maximizeBtnHovered.emit(hwnd_window)
+                    tme = TRACKMOUSEEVENT()
+                    tme.cbSize = ctypes.sizeof(TRACKMOUSEEVENT)
+                    tme.dwFlags = 0x00000002 | 0x00000010
+                    tme.hwndTrack = hwnd_window
+                    tme.dwHoverTime = 0
+                    user32.TrackMouseEvent(ctypes.byref(tme))
+                return False, 0
+
+            if message_id == WM_NCMOUSELEAVE:
+                if self.win_event_manager:
+                    self.win_event_manager.maximizeBtnLeave.emit(hwnd_window)
+                return False, 0
+
+            if message_id == WM_NCLBUTTONDOWN:
+                if w_param == HTMAXBUTTON:
+                    if self.win_event_manager:
+                        self.win_event_manager.maximizeBtnPressed.emit(hwnd_window)
+                    return True, 0
+
+            if message_id == WM_NCLBUTTONUP:
+                if w_param == HTMAXBUTTON:
+                    if self.win_event_manager:
+                        self.win_event_manager.maximizeBtnReleased.emit(hwnd_window)
+                    if is_maximized(hwnd_window):
+                        ShowWindow(hwnd_window, SW_RESTORE)
+                    else:
+                        ShowWindow(hwnd_window, SW_MAXIMIZE)
+                    return True, 0
+
             # 移除标题栏
-            if message_id == WM_NCCALCSIZE and w_param:
-                client_rect = ctypes.cast(
-                    l_param, ctypes.POINTER(NCCALCSIZE_PARAMS)
-                ).contents.rgrc[0]
-                if is_maximized(hwnd):
-                    ty = get_resize_border_thickness(hwnd, False)
-                    client_rect.top += ty
-                    client_rect.bottom -= ty
-                    tx = get_resize_border_thickness(hwnd, True)
-                    client_rect.left += tx
-                    client_rect.right -= tx
-                    abd = APPBARDATA()
-                    ctypes.memset(ctypes.byref(abd), 0, ctypes.sizeof(abd))
-                    abd.cbSize = ctypes.sizeof(APPBARDATA)
-                    taskbar_state = ctypes.windll.shell32.SHAppBarMessage(
-                        ABM_GETSTATE, ctypes.byref(abd)
-                    )
-                    if taskbar_state & ABS_AUTOHIDE:
-                        edge = -1
-                        abd2 = APPBARDATA()
-                        ctypes.memset(ctypes.byref(abd2), 0, ctypes.sizeof(abd2))
-                        abd2.cbSize = ctypes.sizeof(APPBARDATA)
-                        abd2.hWnd = FindWindow("Shell_TrayWnd", None)
-                        if abd2.hWnd:
-                            window_monitor = MonitorFromWindow(
-                                hwnd, MONITOR_DEFAULTTONEAREST
-                            )
-                            if window_monitor:
-                                taskbar_monitor = MonitorFromWindow(
-                                    abd2.hWnd, MONITOR_DEFAULTTOPRIMARY
+            if message_id == WM_NCCALCSIZE:
+                if w_param:
+                    client_rect = ctypes.cast(
+                        l_param, ctypes.POINTER(NCCALCSIZE_PARAMS)
+                    ).contents.rgrc[0]
+                    if is_maximized(hwnd):
+                        ty = get_resize_border_thickness(hwnd, False)
+                        client_rect.top += ty
+                        client_rect.bottom -= ty
+                        tx = get_resize_border_thickness(hwnd, True)
+                        client_rect.left += tx
+                        client_rect.right -= tx
+                        abd = APPBARDATA()
+                        ctypes.memset(ctypes.byref(abd), 0, ctypes.sizeof(abd))
+                        abd.cbSize = ctypes.sizeof(APPBARDATA)
+                        taskbar_state = ctypes.windll.shell32.SHAppBarMessage(
+                            ABM_GETSTATE, ctypes.byref(abd)
+                        )
+                        if taskbar_state & ABS_AUTOHIDE:
+                            edge = -1
+                            abd2 = APPBARDATA()
+                            ctypes.memset(ctypes.byref(abd2), 0, ctypes.sizeof(abd2))
+                            abd2.cbSize = ctypes.sizeof(APPBARDATA)
+                            abd2.hWnd = FindWindow("Shell_TrayWnd", None)
+                            if abd2.hWnd:
+                                window_monitor = MonitorFromWindow(
+                                    hwnd, MONITOR_DEFAULTTONEAREST
                                 )
-                                if (
-                                    taskbar_monitor
-                                    and taskbar_monitor == window_monitor
-                                ):
-                                    ctypes.windll.shell32.SHAppBarMessage(
-                                        ABM_GETTASKBARPOS, ctypes.byref(abd2)
+                                if window_monitor:
+                                    taskbar_monitor = MonitorFromWindow(
+                                        abd2.hWnd, MONITOR_DEFAULTTOPRIMARY
                                     )
-                                    edge = abd2.uEdge
-                        top = edge == 1
-                        bottom = edge == 3
-                        left = edge == 0
-                        right = edge == 2
-                        if top:
-                            client_rect.top += 1
-                        elif bottom:
-                            client_rect.bottom -= 1
-                        elif left:
-                            client_rect.left += 1
-                        elif right:
-                            client_rect.right -= 1
-                        else:
-                            client_rect.bottom -= 1
-                return True, 0
+                                    if (
+                                        taskbar_monitor
+                                        and taskbar_monitor == window_monitor
+                                    ):
+                                        ctypes.windll.shell32.SHAppBarMessage(
+                                            ABM_GETTASKBARPOS, ctypes.byref(abd2)
+                                        )
+                                        edge = abd2.uEdge
+                            top = edge == 1
+                            bottom = edge == 3
+                            left = edge == 0
+                            right = edge == 2
+                            if top:
+                                client_rect.top += 1
+                            elif bottom:
+                                client_rect.bottom -= 1
+                            elif left:
+                                client_rect.left += 1
+                            elif right:
+                                client_rect.right -= 1
+                            else:
+                                client_rect.bottom -= 1
+                return True, WVR_REDRAW if w_param else 0
+
+            if message_id == WM_SIZE:
+                margins = (ctypes.c_int * 4)(0, 0, 0, 1)
+                ctypes.windll.dwmapi.DwmExtendFrameIntoClientArea(
+                    hwnd_window, ctypes.byref(margins)
+                )
+                return False, 0
 
             # 支持动画
             if message_id == WM_SYSCOMMAND:
@@ -373,10 +542,10 @@ class WinEventFilter(QAbstractNativeEventFilter):
                     monitor_info.rcWork.top - monitor_info.rcMonitor.top
                 )
                 minmax_info.ptMaxSize.x = (
-                    monitor_info.rcWork.right - monitor_info.rcMonitor.left
+                    monitor_info.rcWork.right - monitor_info.rcWork.left
                 )
                 minmax_info.ptMaxSize.y = (
-                    monitor_info.rcWork.bottom - monitor_info.rcMonitor.top
+                    monitor_info.rcWork.bottom - monitor_info.rcWork.top
                 )
 
                 def get_window_int_property(window, name, default):

--- a/RinUI/windows/CtrlBtn.qml
+++ b/RinUI/windows/CtrlBtn.qml
@@ -13,6 +13,9 @@ Base {
     property alias icon: icon.icon
     property alias localHovered: hoverHandler.hovered
     property alias localPressed: mouseArea.pressed
+    // Native non-client hover/press state driven by WinEventManager for Snap Layout.
+    property bool nativeHovered: false
+    property bool nativePressed: false
     // Keep macOS detection resilient across Qt variants.
     property bool macStyle: Qt.platform.os === "osx" || Qt.platform.os === "macos" || Qt.platform.os === "darwin"
     property bool macGroupHovered: false
@@ -25,7 +28,7 @@ Base {
     ToolTip {
         parent: parent
         delay: 500
-        visible: !macStyle && hoverHandler.hovered
+        visible: !macStyle && (hoverHandler.hovered || root.nativeHovered)
         text: mode === 0 ? qsTr("Maximize") : mode === 1 ? qsTr("Minimize") : mode === 2 ? qsTr("Close") : qsTr("Unknown")
     }
 
@@ -214,7 +217,7 @@ Base {
         },
         State {
             name: "pressedCtrl"
-            when: !macStyle && mouseArea.pressed
+            when: !macStyle && (mouseArea.pressed || root.nativePressed)
             PropertyChanges {
                 target: background;
                 opacity: 0.8
@@ -227,7 +230,7 @@ Base {
         },
         State {
             name: "hoveredCtrl"
-            when: !macStyle && hoverHandler.hovered
+            when: !macStyle && (hoverHandler.hovered || root.nativeHovered)
             PropertyChanges {
                 target: background;
                 opacity: 1

--- a/RinUI/windows/FluentWindow.qml
+++ b/RinUI/windows/FluentWindow.qml
@@ -13,7 +13,7 @@ FluentWindowBase {
     minimumWidth: 400
     minimumHeight: 300
     titleEnabled: false
-    titleBarHeight: useNativeMacFrame ? 36 : Theme.currentTheme.appearance.windowTitleBarHeight
+    titleBarHeight: Theme.currentTheme.appearance.windowTitleBarHeight
 
     property alias navigationView: navigationView  // 导航栏
     property alias navigationItems: navigationView.navigationItems  // 导航栏item

--- a/RinUI/windows/FluentWindowBase.qml
+++ b/RinUI/windows/FluentWindowBase.qml
@@ -18,7 +18,7 @@ ApplicationWindow {
     // Native traffic lights + single custom titlebar integration on macOS.
     property bool useNativeMacFrame: isMacOS
     // Fine-tune custom title content baseline to match native traffic lights.
-    property int macNativeContentVerticalOffset: useNativeMacFrame ? -2 : 0
+    property int macNativeContentVerticalOffset: 0
     property int expandedClientAreaHint: typeof Qt.ExpandedClientAreaHint !== "undefined"
         ? Qt.ExpandedClientAreaHint
         : 0
@@ -79,9 +79,9 @@ ApplicationWindow {
     ColumnLayout {
         anchors.fill: parent
         // anchors.topMargin: Utils.windowDragArea
-        anchors.bottomMargin: baseWindow.useNativeMacFrame ? 0 : Utils.windowDragArea
-        anchors.leftMargin: baseWindow.useNativeMacFrame ? 0 : Utils.windowDragArea
-        anchors.rightMargin: baseWindow.useNativeMacFrame ? 0 : Utils.windowDragArea
+        anchors.bottomMargin: Utils.windowDragArea
+        anchors.leftMargin: Utils.windowDragArea
+        anchors.rightMargin: Utils.windowDragArea
         spacing: 0
 
         // 顶部边距

--- a/RinUI/windows/TitleBar.qml
+++ b/RinUI/windows/TitleBar.qml
@@ -115,7 +115,7 @@ Item {
         color: "transparent"
 
         MouseArea {
-            enabled: !root.useNativeMacControls
+            enabled: Qt.platform.os !== "windows"
             anchors.fill: parent
             anchors.leftMargin: root.isMacOS
                 ? root.macLeadingInset + root.macLeadingInteractiveWidth

--- a/RinUI/windows/TitleBar.qml
+++ b/RinUI/windows/TitleBar.qml
@@ -78,6 +78,37 @@ Item {
         WindowManager.maximizeWindow(window)
     }
 
+    // Sync maximize button visual state with native non-client interactions on Windows.
+    Connections {
+        target: (Qt.platform.os === "windows" && typeof WinEventManager !== "undefined") ? WinEventManager : null
+        function onMaximizeBtnHovered(hwnd) {
+            if (!window || WinEventManager.getWindowId(window) !== hwnd) {
+                return
+            }
+            maximizeBtn.nativeHovered = true
+        }
+        function onMaximizeBtnLeave(hwnd) {
+            if (!window || WinEventManager.getWindowId(window) !== hwnd) {
+                return
+            }
+            maximizeBtn.nativeHovered = false
+            maximizeBtn.nativePressed = false
+        }
+        function onMaximizeBtnPressed(hwnd) {
+            if (!window || WinEventManager.getWindowId(window) !== hwnd) {
+                return
+            }
+            maximizeBtn.nativePressed = true
+        }
+        function onMaximizeBtnReleased(hwnd) {
+            if (!window || WinEventManager.getWindowId(window) !== hwnd) {
+                return
+            }
+            maximizeBtn.nativePressed = false
+            maximizeBtn.nativeHovered = false
+        }
+    }
+
     Rectangle{
         id:rectBk
         anchors.fill: parent
@@ -95,22 +126,25 @@ Item {
             property point clickPos: "0,0"
 
             onPressed: {
-                clickPos = Qt.point(mouseX, mouseY)
-
-                if (Qt.platform.os !== "windows" || !WindowManager._isWinMgrInitialized()) {
+                if (Qt.platform.os === "windows") {
                     return
                 }
-                WindowManager.sendDragWindowEvent(window)
+
+                clickPos = Qt.point(mouseX, mouseY)
             }
-            onDoubleClicked: toggleMaximized()
+            onDoubleClicked: {
+                if (Qt.platform.os === "windows") {
+                    return
+                }
+                toggleMaximized()
+            }
             onPositionChanged: (mouse) => {
+                if (Qt.platform.os === "windows") {
+                    return
+                }
+
                 if (window.isMaximized || window.isFullScreen || window.visibility === Window.Maximized) {
                     return
-                }
-
-                if (Qt.platform.os !== "windows" && WindowManager._isWinMgrInitialized()) {
-                    log("Windows only")
-                    return  // 在win环境使用原生方法拖拽
                 }
 
                 //鼠标偏移量

--- a/RinUI/windows/window/Window.qml
+++ b/RinUI/windows/window/Window.qml
@@ -11,7 +11,7 @@ Window {
     // Native traffic lights + single custom titlebar integration on macOS.
     property bool useNativeMacFrame: isMacOS
     // Fine-tune custom title content baseline to match native traffic lights.
-    property int macNativeContentVerticalOffset: useNativeMacFrame ? -2 : 0
+    property int macNativeContentVerticalOffset: 0
     property int expandedClientAreaHint: typeof Qt.ExpandedClientAreaHint !== "undefined"
         ? Qt.ExpandedClientAreaHint
         : 0
@@ -46,9 +46,9 @@ Window {
     // 布局
     ColumnLayout {
         anchors.fill: parent
-        anchors.bottomMargin: baseWindow.useNativeMacFrame ? 0 : Utils.windowDragArea
-        anchors.leftMargin: baseWindow.useNativeMacFrame ? 0 : Utils.windowDragArea
-        anchors.rightMargin: baseWindow.useNativeMacFrame ? 0 : Utils.windowDragArea
+        anchors.bottomMargin: Utils.windowDragArea
+        anchors.leftMargin: Utils.windowDragArea
+        anchors.rightMargin: Utils.windowDragArea
         spacing: 0
 
         // 顶部边距


### PR DESCRIPTION
添加windows11 snap layout支持 Fixes https://github.com/RinLit-233-shiroko/Rin-UI/issues/46
修复了窗口特定情况下无法拖动 Fixes https://github.com/RinLit-233-shiroko/Rin-UI/issues/89
修复了最大化时无法通过拖动标题栏恢复窗口模式 Fixes https://github.com/RinLit-233-shiroko/Rin-UI/issues/77
修复macOS引入了红绿灯后无法拖动窗口 Fixes https://github.com/RinLit-233-shiroko/Rin-UI/issues/95

https://github.com/user-attachments/assets/12a4ecce-c6d1-461b-94f4-7fbd239a2afc

