### PR TITLE
refactor(FluentPage): use MultiEffect instead of OpacityMask for HiDPI

### DIFF
--- a/RinUI/components/BasicInput/Button.qml
+++ b/RinUI/components/BasicInput/Button.qml
@@ -48,9 +48,11 @@ Button {
             enabled ? highlighted ? primaryColor : Theme.currentTheme.colors.controlBorderColor :
             highlighted ? Theme.currentTheme.colors.disabledColor : Theme.currentTheme.colors.controlBorderColor
 
-        // 裁切
+        // 仅裁切底部指示条；smooth:false 避免 HiDPI 下边缘发糊
+        // 文字在 contentItem 中直接绘制，不受此 layer 影响
         layer.enabled: true
-        layer.smooth: true
+        layer.smooth: false
+        layer.mipmap: false
         layer.effect: OpacityMask {
             maskSource: Rectangle {
                 width: background.width

--- a/RinUI/components/BasicInput/ComboBox.qml
+++ b/RinUI/components/BasicInput/ComboBox.qml
@@ -42,9 +42,10 @@ ComboBox {
         border.width: Theme.currentTheme.appearance.borderWidth  // 边框宽度 / Border Width
         border.color: Theme.currentTheme.colors.controlBorderColor
 
-        // 裁切
+        // 仅裁切底部指示条；smooth:false 避免 HiDPI 下边缘发糊
         layer.enabled: true
-        layer.smooth: true
+        layer.smooth: false
+        layer.mipmap: false
         layer.effect: OpacityMask {
             maskSource: Rectangle {
                 width: background.width

--- a/RinUI/components/Layout/Expander.qml
+++ b/RinUI/components/Layout/Expander.qml
@@ -1,12 +1,13 @@
 import QtQuick 2.15
 import QtQuick.Controls.Basic 2.15
 import QtQuick.Layouts 2.15
-import Qt5Compat.GraphicalEffects
 import "../../themes"
 import "../../components"
 
 
 // expander
+// HiDPI: 不对含文字的整控件使用 layer+OpacityMask（会糊字）。
+// 圆角交给 header / content 自身的 radius，文字直接绘制。
 Item {
     id: root
     property bool enabled: true
@@ -53,7 +54,12 @@ Item {
             48
         )
         border.color: Theme.currentTheme.colors.cardBorderColor
-        radius: 0
+        // 折叠时全圆角；展开时与 content 衔接侧直角，外侧保留圆角（分角半径，避免整控件 layer）
+        radius: root.radius
+        topLeftRadius: (!expanded || !directionUp) ? root.radius : 0
+        topRightRadius: (!expanded || !directionUp) ? root.radius : 0
+        bottomLeftRadius: (!expanded || directionUp) ? root.radius : 0
+        bottomRightRadius: (!expanded || directionUp) ? root.radius : 0
 
         RowLayout {
             id: headerCustom
@@ -120,7 +126,11 @@ Item {
             y: expanded
                 ? directionUp ? 2 : - 2
                 : directionUp ? height : - height
-            radius: 0
+            radius: root.radius
+            topLeftRadius: directionUp ? root.radius : 0
+            topRightRadius: directionUp ? root.radius : 0
+            bottomLeftRadius: directionUp ? 0 : root.radius
+            bottomRightRadius: directionUp ? 0 : root.radius
             opacity: root.enabled ? 1 : 0.65
 
             color: Theme.currentTheme.colors.cardSecondaryColor
@@ -147,15 +157,5 @@ Item {
     // 动画
     Behavior on implicitHeight {
         NumberAnimation { duration: Utils.animationSpeedExpander; easing.type: expanded ? Easing.InQuint : Easing.OutQuint }
-    }
-
-    // 圆角裁切
-    layer.enabled: true
-    layer.effect: OpacityMask {
-        maskSource: Rectangle {
-            width: root.width
-            height: root.height
-            radius: root.radius
-        }
     }
 }

--- a/RinUI/components/Layout/RoundedCornerOverlay.qml
+++ b/RinUI/components/Layout/RoundedCornerOverlay.qml
@@ -1,9 +1,8 @@
 import QtQuick 2.15
-import QtQuick.Shapes 1.15
 import "../../themes"
 
 // 内容卡片圆角「外侧」遮罩：盖住直角溢出像素，不把文字送进 layer，避免 HiDPI 糊字。
-// 用法：叠在 StackView / 页面之上，与 appLayer.radius 对齐。
+// 用 Canvas 画准几何（避免 Shape PathArc 圆心/方向推断错误）。
 Item {
     id: root
 
@@ -14,130 +13,164 @@ Item {
     property bool bottomLeft: true
     property bool bottomRight: true
 
-    // radius<=0 时不绘制（如最大化）
-    visible: radius > 0.5 && (topLeft || topRight || bottomLeft || bottomRight)
-    enabled: false  // 不拦截鼠标，点击穿透到下层页面
+    // 略放大以盖住抗锯齿缝
+    readonly property real paintRadius: Math.max(0, radius)
+    readonly property real cornerSize: paintRadius > 0 ? paintRadius + 1 : 0
+
+    visible: paintRadius > 0.5 && (topLeft || topRight || bottomLeft || bottomRight)
+    enabled: false
     clip: false
 
-    readonly property real r: Math.max(0, radius)
+    onRadiusChanged: repaintAll()
+    onFillColorChanged: repaintAll()
+    onWidthChanged: repaintAll()
+    onHeightChanged: repaintAll()
+    onTopLeftChanged: repaintAll()
+    onTopRightChanged: repaintAll()
+    onBottomLeftChanged: repaintAll()
+    onBottomRightChanged: repaintAll()
+    onVisibleChanged: if (visible) repaintAll()
+
+    function repaintAll() {
+        if (tlCanvas.available) tlCanvas.requestPaint()
+        if (trCanvas.available) trCanvas.requestPaint()
+        if (blCanvas.available) blCanvas.requestPaint()
+        if (brCanvas.available) brCanvas.requestPaint()
+    }
 
     Component.onCompleted: {
         console.log(
-            "[RinUI/RoundedCornerOverlay] radius=" + root.r
+            "[RinUI/RoundedCornerOverlay] canvas corners radius=" + paintRadius
             + " fill=" + fillColor
             + " size=" + width + "x" + height
         )
+        repaintAll()
     }
 
-    // 左上：方块减四分之一圆（外侧）
-    Shape {
-        width: root.r
-        height: root.r
+    // 左上：角点 (0,0)，圆心 (r,r)，外侧扇形
+    Canvas {
+        id: tlCanvas
+        width: root.cornerSize
+        height: root.cornerSize
         anchors.left: parent.left
         anchors.top: parent.top
-        visible: root.topLeft && root.r > 0
+        visible: root.topLeft && root.paintRadius > 0
         antialiasing: true
-        preferredRendererType: Shape.CurveRenderer
+        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
 
-        ShapePath {
-            fillColor: root.fillColor
-            strokeWidth: 0
-            startX: 0
-            startY: 0
-            PathLine { x: root.r; y: 0 }
-            PathArc {
-                x: 0
-                y: root.r
-                radiusX: root.r
-                radiusY: root.r
-                useLargeArc: false
-                direction: PathArc.Clockwise
-            }
-            PathLine { x: 0; y: 0 }
+        onPaint: {
+            var ctx = getContext("2d")
+            var r = root.paintRadius
+            var s = root.cornerSize
+            ctx.reset()
+            if (r <= 0) return
+            ctx.clearRect(0, 0, s, s)
+            ctx.fillStyle = root.fillColor
+            ctx.beginPath()
+            ctx.moveTo(0, 0)
+            ctx.lineTo(r, 0)
+            // 圆心 (r,r)：从顶部 (r,0) 逆时针到左侧 (0,r) —— 圆角内侧边界
+            ctx.arc(r, r, r, -Math.PI / 2, Math.PI, true)
+            ctx.closePath()
+            ctx.fill()
         }
     }
 
-    // 右上
-    Shape {
-        width: root.r
-        height: root.r
+    // 右上：角点 (w,0) 局部 (s,0)，圆心 (s-r, r)
+    Canvas {
+        id: trCanvas
+        width: root.cornerSize
+        height: root.cornerSize
         anchors.right: parent.right
         anchors.top: parent.top
-        visible: root.topRight && root.r > 0
+        visible: root.topRight && root.paintRadius > 0
         antialiasing: true
-        preferredRendererType: Shape.CurveRenderer
+        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
 
-        ShapePath {
-            fillColor: root.fillColor
-            strokeWidth: 0
-            startX: root.r
-            startY: 0
-            PathLine { x: 0; y: 0 }
-            PathArc {
-                x: root.r
-                y: root.r
-                radiusX: root.r
-                radiusY: root.r
-                useLargeArc: false
-                direction: PathArc.Clockwise
-            }
-            PathLine { x: root.r; y: 0 }
+        onPaint: {
+            var ctx = getContext("2d")
+            var r = root.paintRadius
+            var s = root.cornerSize
+            ctx.reset()
+            if (r <= 0) return
+            ctx.clearRect(0, 0, s, s)
+            ctx.fillStyle = root.fillColor
+            var cx = s - r
+            ctx.beginPath()
+            ctx.moveTo(s, 0)
+            ctx.lineTo(cx, 0)
+            // 从 (cx,0) 顺时针到 (s,r) —— 相对圆心 (cx,r) 从 -π/2 到 0
+            ctx.arc(cx, r, r, -Math.PI / 2, 0, false)
+            ctx.lineTo(s, 0)
+            ctx.closePath()
+            ctx.fill()
         }
     }
 
-    // 左下
-    Shape {
-        width: root.r
-        height: root.r
+    // 左下：角点 (0,h) 局部 (0,s)，圆心 (r, s-r)
+    Canvas {
+        id: blCanvas
+        width: root.cornerSize
+        height: root.cornerSize
         anchors.left: parent.left
         anchors.bottom: parent.bottom
-        visible: root.bottomLeft && root.r > 0
+        visible: root.bottomLeft && root.paintRadius > 0
         antialiasing: true
-        preferredRendererType: Shape.CurveRenderer
+        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
 
-        ShapePath {
-            fillColor: root.fillColor
-            strokeWidth: 0
-            startX: 0
-            startY: root.r
-            PathLine { x: 0; y: 0 }
-            PathArc {
-                x: root.r
-                y: root.r
-                radiusX: root.r
-                radiusY: root.r
-                useLargeArc: false
-                direction: PathArc.Clockwise
-            }
-            PathLine { x: 0; y: root.r }
+        onPaint: {
+            var ctx = getContext("2d")
+            var r = root.paintRadius
+            var s = root.cornerSize
+            ctx.reset()
+            if (r <= 0) return
+            ctx.clearRect(0, 0, s, s)
+            ctx.fillStyle = root.fillColor
+            var cy = s - r
+            ctx.beginPath()
+            ctx.moveTo(0, s)
+            ctx.lineTo(0, cy)
+            // 从 (0,cy) 顺时针到 (r,s) —— 圆心 (r,cy) 从 π 到 π/2
+            ctx.arc(r, cy, r, Math.PI, Math.PI / 2, true)
+            ctx.lineTo(0, s)
+            ctx.closePath()
+            ctx.fill()
         }
     }
 
-    // 右下
-    Shape {
-        width: root.r
-        height: root.r
+    // 右下：角点 (w,h) 局部 (s,s)，圆心 (s-r, s-r)
+    Canvas {
+        id: brCanvas
+        width: root.cornerSize
+        height: root.cornerSize
         anchors.right: parent.right
         anchors.bottom: parent.bottom
-        visible: root.bottomRight && root.r > 0
+        visible: root.bottomRight && root.paintRadius > 0
         antialiasing: true
-        preferredRendererType: Shape.CurveRenderer
+        renderTarget: Canvas.FramebufferObject
+        renderStrategy: Canvas.Cooperative
 
-        ShapePath {
-            fillColor: root.fillColor
-            strokeWidth: 0
-            startX: root.r
-            startY: root.r
-            PathLine { x: root.r; y: 0 }
-            PathArc {
-                x: 0
-                y: root.r
-                radiusX: root.r
-                radiusY: root.r
-                useLargeArc: false
-                direction: PathArc.Clockwise
-            }
-            PathLine { x: root.r; y: root.r }
+        onPaint: {
+            var ctx = getContext("2d")
+            var r = root.paintRadius
+            var s = root.cornerSize
+            ctx.reset()
+            if (r <= 0) return
+            ctx.clearRect(0, 0, s, s)
+            ctx.fillStyle = root.fillColor
+            var cx = s - r
+            var cy = s - r
+            ctx.beginPath()
+            ctx.moveTo(s, s)
+            ctx.lineTo(s, cy)
+            // 从 (s,cy) 逆时针到 (cx,s) —— 圆心 (cx,cy) 从 0 到 π/2
+            ctx.arc(cx, cy, r, 0, Math.PI / 2, false)
+            ctx.lineTo(s, s)
+            ctx.closePath()
+            ctx.fill()
         }
     }
 }

--- a/RinUI/components/Layout/RoundedCornerOverlay.qml
+++ b/RinUI/components/Layout/RoundedCornerOverlay.qml
@@ -1,8 +1,8 @@
 import QtQuick 2.15
 import "../../themes"
 
-// 内容卡片圆角「外侧」遮罩：盖住直角溢出像素，不把文字送进 layer，避免 HiDPI 糊字。
-// 用 Canvas 画准几何（避免 Shape PathArc 圆心/方向推断错误）。
+// 内容卡片圆角「外侧」遮罩：盖住直角溢出，不把文字送进 layer（HiDPI 安全）。
+// 单 Canvas + evenodd：角矩形 ∪ 圆，奇偶填充后只剩圆角外侧，四角同一算法。
 Item {
     id: root
 
@@ -13,164 +13,102 @@ Item {
     property bool bottomLeft: true
     property bool bottomRight: true
 
-    // 略放大以盖住抗锯齿缝
-    readonly property real paintRadius: Math.max(0, radius)
-    readonly property real cornerSize: paintRadius > 0 ? paintRadius + 1 : 0
+    readonly property real paintRadius: Math.max(0, Math.round(radius))
 
-    visible: paintRadius > 0.5 && (topLeft || topRight || bottomLeft || bottomRight)
+    visible: paintRadius > 0 && width > 1 && height > 1
+        && (topLeft || topRight || bottomLeft || bottomRight)
     enabled: false
     clip: false
 
-    onRadiusChanged: repaintAll()
-    onFillColorChanged: repaintAll()
-    onWidthChanged: repaintAll()
-    onHeightChanged: repaintAll()
-    onTopLeftChanged: repaintAll()
-    onTopRightChanged: repaintAll()
-    onBottomLeftChanged: repaintAll()
-    onBottomRightChanged: repaintAll()
-    onVisibleChanged: if (visible) repaintAll()
+    onRadiusChanged: schedulePaint()
+    onFillColorChanged: schedulePaint()
+    onWidthChanged: schedulePaint()
+    onHeightChanged: schedulePaint()
+    onTopLeftChanged: schedulePaint()
+    onTopRightChanged: schedulePaint()
+    onBottomLeftChanged: schedulePaint()
+    onBottomRightChanged: schedulePaint()
+    onVisibleChanged: if (visible) schedulePaint()
 
-    function repaintAll() {
-        if (tlCanvas.available) tlCanvas.requestPaint()
-        if (trCanvas.available) trCanvas.requestPaint()
-        if (blCanvas.available) blCanvas.requestPaint()
-        if (brCanvas.available) brCanvas.requestPaint()
+    function schedulePaint() {
+        paintTimer.restart()
+    }
+
+    Timer {
+        id: paintTimer
+        interval: 16
+        repeat: false
+        onTriggered: {
+            if (cornerCanvas.available)
+                cornerCanvas.requestPaint()
+        }
     }
 
     Component.onCompleted: {
         console.log(
-            "[RinUI/RoundedCornerOverlay] canvas corners radius=" + paintRadius
+            "[RinUI/RoundedCornerOverlay] evenodd canvas radius=" + paintRadius
             + " fill=" + fillColor
-            + " size=" + width + "x" + height
+            + " size=" + Math.round(width) + "x" + Math.round(height)
         )
-        repaintAll()
+        schedulePaint()
     }
 
-    // 左上：角点 (0,0)，圆心 (r,r)，外侧扇形
     Canvas {
-        id: tlCanvas
-        width: root.cornerSize
-        height: root.cornerSize
-        anchors.left: parent.left
-        anchors.top: parent.top
-        visible: root.topLeft && root.paintRadius > 0
+        id: cornerCanvas
+        anchors.fill: parent
         antialiasing: true
-        renderTarget: Canvas.FramebufferObject
-        renderStrategy: Canvas.Cooperative
+        renderTarget: Canvas.Image
+        renderStrategy: Canvas.Immediate
 
+        onWidthChanged: root.schedulePaint()
+        onHeightChanged: root.schedulePaint()
         onPaint: {
             var ctx = getContext("2d")
+            var w = width
+            var h = height
             var r = root.paintRadius
-            var s = root.cornerSize
+            var fill = root.fillColor
+
             ctx.reset()
-            if (r <= 0) return
-            ctx.clearRect(0, 0, s, s)
-            ctx.fillStyle = root.fillColor
-            ctx.beginPath()
-            ctx.moveTo(0, 0)
-            ctx.lineTo(r, 0)
-            // 圆心 (r,r)：从顶部 (r,0) 逆时针到左侧 (0,r) —— 圆角内侧边界
-            ctx.arc(r, r, r, -Math.PI / 2, Math.PI, true)
-            ctx.closePath()
-            ctx.fill()
-        }
-    }
+            ctx.clearRect(0, 0, w, h)
 
-    // 右上：角点 (w,0) 局部 (s,0)，圆心 (s-r, r)
-    Canvas {
-        id: trCanvas
-        width: root.cornerSize
-        height: root.cornerSize
-        anchors.right: parent.right
-        anchors.top: parent.top
-        visible: root.topRight && root.paintRadius > 0
-        antialiasing: true
-        renderTarget: Canvas.FramebufferObject
-        renderStrategy: Canvas.Cooperative
+            if (r <= 0 || w <= 1 || h <= 1)
+                return
 
-        onPaint: {
-            var ctx = getContext("2d")
-            var r = root.paintRadius
-            var s = root.cornerSize
-            ctx.reset()
-            if (r <= 0) return
-            ctx.clearRect(0, 0, s, s)
-            ctx.fillStyle = root.fillColor
-            var cx = s - r
-            ctx.beginPath()
-            ctx.moveTo(s, 0)
-            ctx.lineTo(cx, 0)
-            // 从 (cx,0) 顺时针到 (s,r) —— 相对圆心 (cx,r) 从 -π/2 到 0
-            ctx.arc(cx, r, r, -Math.PI / 2, 0, false)
-            ctx.lineTo(s, 0)
-            ctx.closePath()
-            ctx.fill()
-        }
-    }
+            r = Math.min(r, Math.floor(w / 2), Math.floor(h / 2))
+            if (r <= 0)
+                return
 
-    // 左下：角点 (0,h) 局部 (0,s)，圆心 (r, s-r)
-    Canvas {
-        id: blCanvas
-        width: root.cornerSize
-        height: root.cornerSize
-        anchors.left: parent.left
-        anchors.bottom: parent.bottom
-        visible: root.bottomLeft && root.paintRadius > 0
-        antialiasing: true
-        renderTarget: Canvas.FramebufferObject
-        renderStrategy: Canvas.Cooperative
+            ctx.fillStyle = fill
 
-        onPaint: {
-            var ctx = getContext("2d")
-            var r = root.paintRadius
-            var s = root.cornerSize
-            ctx.reset()
-            if (r <= 0) return
-            ctx.clearRect(0, 0, s, s)
-            ctx.fillStyle = root.fillColor
-            var cy = s - r
-            ctx.beginPath()
-            ctx.moveTo(0, s)
-            ctx.lineTo(0, cy)
-            // 从 (0,cy) 顺时针到 (r,s) —— 圆心 (r,cy) 从 π 到 π/2
-            ctx.arc(r, cy, r, Math.PI, Math.PI / 2, true)
-            ctx.lineTo(0, s)
-            ctx.closePath()
-            ctx.fill()
-        }
-    }
+            // evenodd：矩形路径 + 圆路径 → 只保留矩形中圆外的区域（圆角外侧）
+            function stampOutside(x0, y0, cx, cy) {
+                ctx.beginPath()
+                ctx.rect(x0, y0, r, r)
+                ctx.moveTo(cx + r, cy)
+                ctx.arc(cx, cy, r, 0, Math.PI * 2, false)
+                ctx.fill("evenodd")
+            }
 
-    // 右下：角点 (w,h) 局部 (s,s)，圆心 (s-r, s-r)
-    Canvas {
-        id: brCanvas
-        width: root.cornerSize
-        height: root.cornerSize
-        anchors.right: parent.right
-        anchors.bottom: parent.bottom
-        visible: root.bottomRight && root.paintRadius > 0
-        antialiasing: true
-        renderTarget: Canvas.FramebufferObject
-        renderStrategy: Canvas.Cooperative
+            if (root.topLeft)
+                stampOutside(0, 0, r, r)
+            if (root.topRight)
+                stampOutside(w - r, 0, w - r, r)
+            if (root.bottomLeft)
+                stampOutside(0, h - r, r, h - r)
+            if (root.bottomRight)
+                stampOutside(w - r, h - r, w - r, h - r)
 
-        onPaint: {
-            var ctx = getContext("2d")
-            var r = root.paintRadius
-            var s = root.cornerSize
-            ctx.reset()
-            if (r <= 0) return
-            ctx.clearRect(0, 0, s, s)
-            ctx.fillStyle = root.fillColor
-            var cx = s - r
-            var cy = s - r
-            ctx.beginPath()
-            ctx.moveTo(s, s)
-            ctx.lineTo(s, cy)
-            // 从 (s,cy) 逆时针到 (cx,s) —— 圆心 (cx,cy) 从 0 到 π/2
-            ctx.arc(cx, cy, r, 0, Math.PI / 2, false)
-            ctx.lineTo(s, s)
-            ctx.closePath()
-            ctx.fill()
+            console.log(
+                "[RinUI/RoundedCornerOverlay] painted "
+                + Math.round(w) + "x" + Math.round(h)
+                + " r=" + r
+                + " corners="
+                + (root.topLeft ? "TL " : "")
+                + (root.topRight ? "TR " : "")
+                + (root.bottomLeft ? "BL " : "")
+                + (root.bottomRight ? "BR" : "")
+            )
         }
     }
 }

--- a/RinUI/components/Layout/RoundedCornerOverlay.qml
+++ b/RinUI/components/Layout/RoundedCornerOverlay.qml
@@ -9,10 +9,11 @@ Item {
 
     property real radius: Theme.currentTheme.appearance.windowRadius
     property color fillColor: Theme.currentTheme.colors.backgroundColor
+    // 默认仅左上：对齐历史 FluentPage 内容裁切（右上补直角，底侧直角）
     property bool topLeft: true
-    property bool topRight: true
-    property bool bottomLeft: true
-    property bool bottomRight: true
+    property bool topRight: false
+    property bool bottomLeft: false
+    property bool bottomRight: false
 
     readonly property real paintRadius: Math.max(0, Math.round(radius))
 

--- a/RinUI/components/Layout/RoundedCornerOverlay.qml
+++ b/RinUI/components/Layout/RoundedCornerOverlay.qml
@@ -2,7 +2,8 @@ import QtQuick 2.15
 import "../../themes"
 
 // 内容卡片圆角「外侧」遮罩：盖住直角溢出，不把文字送进 layer（HiDPI 安全）。
-// 单 Canvas + evenodd：角矩形 ∪ 圆，奇偶填充后只剩圆角外侧，四角同一算法。
+// 算法：角矩形 clip → 填满 → destination-out 挖圆（圆心在内侧角）。
+// 只动角 r×r 区域，避免整圆 evenodd 渗进内容区。
 Item {
     id: root
 
@@ -46,7 +47,7 @@ Item {
 
     Component.onCompleted: {
         console.log(
-            "[RinUI/RoundedCornerOverlay] evenodd canvas radius=" + paintRadius
+            "[RinUI/RoundedCornerOverlay] clip+punch radius=" + paintRadius
             + " fill=" + fillColor
             + " size=" + Math.round(width) + "x" + Math.round(height)
         )
@@ -79,15 +80,24 @@ Item {
             if (r <= 0)
                 return
 
-            ctx.fillStyle = fill
-
-            // evenodd：矩形路径 + 圆路径 → 只保留矩形中圆外的区域（圆角外侧）
+            // 在角矩形内：填色后挖掉内侧圆，只留圆角外侧
             function stampOutside(x0, y0, cx, cy) {
+                ctx.save()
                 ctx.beginPath()
                 ctx.rect(x0, y0, r, r)
-                ctx.moveTo(cx + r, cy)
-                ctx.arc(cx, cy, r, 0, Math.PI * 2, false)
-                ctx.fill("evenodd")
+                ctx.clip()
+
+                ctx.globalCompositeOperation = "source-over"
+                ctx.fillStyle = fill
+                ctx.fillRect(x0, y0, r, r)
+
+                ctx.globalCompositeOperation = "destination-out"
+                ctx.beginPath()
+                ctx.arc(cx, cy, r + 0.5, 0, Math.PI * 2, false)
+                ctx.fill()
+
+                ctx.restore()
+                ctx.globalCompositeOperation = "source-over"
             }
 
             if (root.topLeft)

--- a/RinUI/components/Layout/RoundedCornerOverlay.qml
+++ b/RinUI/components/Layout/RoundedCornerOverlay.qml
@@ -1,0 +1,143 @@
+import QtQuick 2.15
+import QtQuick.Shapes 1.15
+import "../../themes"
+
+// 内容卡片圆角「外侧」遮罩：盖住直角溢出像素，不把文字送进 layer，避免 HiDPI 糊字。
+// 用法：叠在 StackView / 页面之上，与 appLayer.radius 对齐。
+Item {
+    id: root
+
+    property real radius: Theme.currentTheme.appearance.windowRadius
+    property color fillColor: Theme.currentTheme.colors.backgroundColor
+    property bool topLeft: true
+    property bool topRight: true
+    property bool bottomLeft: true
+    property bool bottomRight: true
+
+    // radius<=0 时不绘制（如最大化）
+    visible: radius > 0.5 && (topLeft || topRight || bottomLeft || bottomRight)
+    enabled: false  // 不拦截鼠标，点击穿透到下层页面
+    clip: false
+
+    readonly property real r: Math.max(0, radius)
+
+    Component.onCompleted: {
+        console.log(
+            "[RinUI/RoundedCornerOverlay] radius=" + root.r
+            + " fill=" + fillColor
+            + " size=" + width + "x" + height
+        )
+    }
+
+    // 左上：方块减四分之一圆（外侧）
+    Shape {
+        width: root.r
+        height: root.r
+        anchors.left: parent.left
+        anchors.top: parent.top
+        visible: root.topLeft && root.r > 0
+        antialiasing: true
+        preferredRendererType: Shape.CurveRenderer
+
+        ShapePath {
+            fillColor: root.fillColor
+            strokeWidth: 0
+            startX: 0
+            startY: 0
+            PathLine { x: root.r; y: 0 }
+            PathArc {
+                x: 0
+                y: root.r
+                radiusX: root.r
+                radiusY: root.r
+                useLargeArc: false
+                direction: PathArc.Clockwise
+            }
+            PathLine { x: 0; y: 0 }
+        }
+    }
+
+    // 右上
+    Shape {
+        width: root.r
+        height: root.r
+        anchors.right: parent.right
+        anchors.top: parent.top
+        visible: root.topRight && root.r > 0
+        antialiasing: true
+        preferredRendererType: Shape.CurveRenderer
+
+        ShapePath {
+            fillColor: root.fillColor
+            strokeWidth: 0
+            startX: root.r
+            startY: 0
+            PathLine { x: 0; y: 0 }
+            PathArc {
+                x: root.r
+                y: root.r
+                radiusX: root.r
+                radiusY: root.r
+                useLargeArc: false
+                direction: PathArc.Clockwise
+            }
+            PathLine { x: root.r; y: 0 }
+        }
+    }
+
+    // 左下
+    Shape {
+        width: root.r
+        height: root.r
+        anchors.left: parent.left
+        anchors.bottom: parent.bottom
+        visible: root.bottomLeft && root.r > 0
+        antialiasing: true
+        preferredRendererType: Shape.CurveRenderer
+
+        ShapePath {
+            fillColor: root.fillColor
+            strokeWidth: 0
+            startX: 0
+            startY: root.r
+            PathLine { x: 0; y: 0 }
+            PathArc {
+                x: root.r
+                y: root.r
+                radiusX: root.r
+                radiusY: root.r
+                useLargeArc: false
+                direction: PathArc.Clockwise
+            }
+            PathLine { x: 0; y: root.r }
+        }
+    }
+
+    // 右下
+    Shape {
+        width: root.r
+        height: root.r
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        visible: root.bottomRight && root.r > 0
+        antialiasing: true
+        preferredRendererType: Shape.CurveRenderer
+
+        ShapePath {
+            fillColor: root.fillColor
+            strokeWidth: 0
+            startX: root.r
+            startY: root.r
+            PathLine { x: root.r; y: 0 }
+            PathArc {
+                x: 0
+                y: root.r
+                radiusX: root.r
+                radiusY: root.r
+                useLargeArc: false
+                direction: PathArc.Clockwise
+            }
+            PathLine { x: root.r; y: root.r }
+        }
+    }
+}

--- a/RinUI/components/Layout/SettingExpander.qml
+++ b/RinUI/components/Layout/SettingExpander.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls.Basic 2.15
 import QtQuick.Layouts 2.15
-import Qt5Compat.GraphicalEffects
 import "../../themes"
 import "../../components"
 import "../../utils"

--- a/RinUI/components/ListAndCollections/Clip.qml
+++ b/RinUI/components/ListAndCollections/Clip.qml
@@ -8,6 +8,10 @@ Button {
     id: root
     property alias color: background.color
     property alias radius: background.radius
+    property alias topLeftRadius: background.topLeftRadius
+    property alias topRightRadius: background.topRightRadius
+    property alias bottomLeftRadius: background.bottomLeftRadius
+    property alias bottomRightRadius: background.bottomRightRadius
     property alias border: background.border
     // property alias flat: background.flat
 

--- a/RinUI/components/ListAndCollections/Frame.qml
+++ b/RinUI/components/ListAndCollections/Frame.qml
@@ -11,6 +11,11 @@ Frame {
     property bool hover: false
     property color color: Theme.currentTheme.colors.cardColor
     property alias radius: background.radius
+    // Qt 6.7+ 分角圆角，避免整控件 layer+OpacityMask 导致 HiDPI 文字模糊
+    property real topLeftRadius: -1
+    property real topRightRadius: -1
+    property real bottomLeftRadius: -1
+    property real bottomRightRadius: -1
     property alias border: background.border
 
     clip: true
@@ -23,6 +28,11 @@ Frame {
         id: background
         anchors.fill: parent
         radius: Theme.currentTheme.appearance.smallRadius
+        // -1 表示跟随统一 radius；显式 0/正数用于分角圆角（HiDPI 友好，无需 OpacityMask）
+        topLeftRadius: root.topLeftRadius < 0 ? radius : root.topLeftRadius
+        topRightRadius: root.topRightRadius < 0 ? radius : root.topRightRadius
+        bottomLeftRadius: root.bottomLeftRadius < 0 ? radius : root.bottomLeftRadius
+        bottomRightRadius: root.bottomRightRadius < 0 ? radius : root.bottomRightRadius
         color: root.color
         border.width: Theme.currentTheme.appearance.borderWidth
         border.color: Theme.currentTheme.colors.cardBorderColor

--- a/RinUI/components/Media/Avatar.qml
+++ b/RinUI/components/Media/Avatar.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls.Basic 2.15
 import QtQuick.Layouts 2.15
+import QtQuick.Window 2.15
 import Qt5Compat.GraphicalEffects
 import "../../themes"
 import "../../components"
@@ -16,6 +17,7 @@ Item {
     implicitHeight: size
     opacity: enabled ? 1 : 0.4
 
+    // 圆形底 + 初始文字/图标直接绘制，不走 layer（避免 HiDPI 糊字）
     Rectangle {
         id: background
         anchors.fill: parent
@@ -54,22 +56,28 @@ Item {
         }
     }
 
+    // 仅对图片做圆形遮罩；补 textureSize 并关闭 smooth 以适配 HiDPI
     Image {
         id: image
         source: root.source
         anchors.fill: parent
         fillMode: Image.PreserveAspectCrop
+        visible: root.source !== ""
         smooth: true
-        clip: true
-    }
 
-    // 遮罩
-    layer.enabled: true
-    layer.effect: OpacityMask {
-        maskSource: Rectangle {
-            width: root.width
-            height: root.height
-            radius: background.radius
+        layer.enabled: visible
+        layer.smooth: false
+        layer.mipmap: false
+        layer.textureSize: Qt.size(
+            Math.max(1, Math.ceil(width * Screen.devicePixelRatio)),
+            Math.max(1, Math.ceil(height * Screen.devicePixelRatio))
+        )
+        layer.effect: OpacityMask {
+            maskSource: Rectangle {
+                width: image.width
+                height: image.height
+                radius: background.radius
+            }
         }
     }
 

--- a/RinUI/components/Navigation/NavigationView.qml
+++ b/RinUI/components/Navigation/NavigationView.qml
@@ -241,16 +241,14 @@ RowLayout {
 
         }
 
-        // 库层圆角剪影：盖住页面直角溢出，不重光栅化文字（HiDPI 安全）
+        // 库层圆角剪影：与 StackView 同几何，盖住页面直角溢出（不 layer 文字）
         RoundedCornerOverlay {
             id: contentCornerClip
-            anchors.fill: parent
-            anchors.leftMargin: stackView.anchors.leftMargin
-            anchors.topMargin: stackView.anchors.topMargin
+            anchors.fill: stackView
             z: 1000
             radius: contentArea.contentRadius
             fillColor: Theme.currentTheme.colors.backgroundColor
-            visible: navigationView.contentCornerClipEnabled && radius > 0
+            visible: navigationView.contentCornerClipEnabled && contentArea.contentRadius > 0
         }
 
         Component.onCompleted: {

--- a/RinUI/components/Navigation/NavigationView.qml
+++ b/RinUI/components/Navigation/NavigationView.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 2.15
+import QtQuick.Window 2.15
 import "../../themes"
 import "../../components"
 import "../../windows"
@@ -9,6 +10,8 @@ import "../../windows"
 RowLayout {
     // 外观 / Appearance //
     property bool appLayerEnabled: true  // 应用层背景
+    // 内容卡片圆角：用上层角遮罩裁切（不 layer 文字），与 appLayer.radius 对齐
+    property bool contentCornerClipEnabled: true
     property alias navExpandWidth: navigationBar.expandWidth  // 导航栏宽度
     property alias navMinimumExpandWidth: navigationBar.minimumExpandWidth  // 导航栏保持展开时窗口的最小宽度
 
@@ -74,13 +77,19 @@ RowLayout {
     }
 
     // 主体内容区域
-    // HiDPI: 内容区不使用 layer/OpacityMask 裁切（会糊字）。
-    // 圆角由 appLayer 背景提供；StackView 仅矩形 clip，文字直接绘制保持清晰。
+    // HiDPI 治本：不对 StackView/页面做 layer+OpacityMask（会糊字）。
+    // 圆角底：appLayer；圆角剪影：RoundedCornerOverlay 盖住四角溢出，文字仍直接绘制。
     Item {
         id: contentArea
         Layout.fillWidth: true
         Layout.fillHeight: true
         clip: true
+
+        readonly property real contentRadius: {
+            if (window && window.visibility === Window.Maximized)
+                return 0
+            return Theme.currentTheme.appearance.windowRadius
+        }
 
         // 导航栏展开自动收起
         MouseArea {
@@ -106,7 +115,7 @@ RowLayout {
             border.color: Theme.currentTheme.colors.cardBorderColor
             border.width: 1
             opacity: (window && window.appLayerEnabled !== undefined) ? window.appLayerEnabled : navigationView.appLayerEnabled
-            radius: Theme.currentTheme.appearance.windowRadius
+            radius: contentArea.contentRadius
         }
 
         StackView {
@@ -230,6 +239,18 @@ RowLayout {
 
             initialItem: Item {}
 
+        }
+
+        // 库层圆角剪影：盖住页面直角溢出，不重光栅化文字（HiDPI 安全）
+        RoundedCornerOverlay {
+            id: contentCornerClip
+            anchors.fill: parent
+            anchors.leftMargin: stackView.anchors.leftMargin
+            anchors.topMargin: stackView.anchors.topMargin
+            z: 1000
+            radius: contentArea.contentRadius
+            fillColor: Theme.currentTheme.colors.backgroundColor
+            visible: navigationView.contentCornerClipEnabled && radius > 0
         }
 
         Component.onCompleted: {

--- a/RinUI/components/Navigation/NavigationView.qml
+++ b/RinUI/components/Navigation/NavigationView.qml
@@ -241,13 +241,18 @@ RowLayout {
 
         }
 
-        // 库层圆角剪影：与 StackView 同几何，盖住页面直角溢出（不 layer 文字）
+        // 库层圆角剪影：与旧 FluentPage OpacityMask 一致——仅左上圆角
+        // （右侧/底侧为直角；不 layer 文字，避免 HiDPI 发糊）
         RoundedCornerOverlay {
             id: contentCornerClip
             anchors.fill: stackView
             z: 1000
             radius: contentArea.contentRadius
             fillColor: Theme.currentTheme.colors.backgroundColor
+            topLeft: true
+            topRight: false
+            bottomLeft: false
+            bottomRight: false
             visible: navigationView.contentCornerClipEnabled && contentArea.contentRadius > 0
         }
 

--- a/RinUI/components/Navigation/NavigationView.qml
+++ b/RinUI/components/Navigation/NavigationView.qml
@@ -74,9 +74,13 @@ RowLayout {
     }
 
     // 主体内容区域
+    // HiDPI: 内容区不使用 layer/OpacityMask 裁切（会糊字）。
+    // 圆角由 appLayer 背景提供；StackView 仅矩形 clip，文字直接绘制保持清晰。
     Item {
+        id: contentArea
         Layout.fillWidth: true
         Layout.fillHeight: true
+        clip: true
 
         // 导航栏展开自动收起
         MouseArea {
@@ -110,6 +114,7 @@ RowLayout {
             anchors.fill: parent
             anchors.leftMargin: 1
             anchors.topMargin: 1
+            clip: true
 
             // 切换动画 / Page Transition //
             pushEnter : Transition {

--- a/RinUI/components/StatusAndInfo/ProgressBar.qml
+++ b/RinUI/components/StatusAndInfo/ProgressBar.qml
@@ -31,9 +31,10 @@ ProgressBar {
         color: backgroundColor
     }
 
-    // 遮罩（让指示条圆角可控）
+    // 遮罩（让指示条圆角可控）；smooth:false 避免 HiDPI 滤波发糊
     layer.enabled: true
-    layer.smooth: true
+    layer.smooth: false
+    layer.mipmap: false
     layer.effect: OpacityMask {
         maskSource: Rectangle {
             width: root.width

--- a/RinUI/components/Text/SpinBox.qml
+++ b/RinUI/components/Text/SpinBox.qml
@@ -34,8 +34,10 @@ SpinBox {
         border.width: Theme.currentTheme.appearance.borderWidth
         border.color: Theme.currentTheme.colors.controlBorderColor
 
+        // 仅裁切背景指示条；文字在 contentItem 直接绘制
         layer.enabled: true
         layer.smooth: false
+        layer.mipmap: false
         layer.effect: OpacityMask {
             maskSource: Rectangle {
                 width: background.width

--- a/RinUI/components/Text/TextArea.qml
+++ b/RinUI/components/Text/TextArea.qml
@@ -44,8 +44,10 @@ TextArea {
         border.color: frameless ? root.activeFocus ? Theme.currentTheme.colors.controlBorderColor : "transparent" :
             Theme.currentTheme.colors.controlBorderColor
 
+        // 仅裁切背景指示条；文字在 contentItem 直接绘制
         layer.enabled: true
         layer.smooth: false
+        layer.mipmap: false
         layer.effect: OpacityMask {
             maskSource: Rectangle {
                 width: background.width

--- a/RinUI/components/Text/TextField.qml
+++ b/RinUI/components/Text/TextField.qml
@@ -45,8 +45,10 @@ TextField {
         border.color: frameless ? root.activeFocus ? Theme.currentTheme.colors.controlBorderColor : "transparent" :
             Theme.currentTheme.colors.controlBorderColor
 
+        // 仅裁切背景指示条；文字在 contentItem 直接绘制
         layer.enabled: true
         layer.smooth: false
+        layer.mipmap: false
         layer.effect: OpacityMask {
             maskSource: Rectangle {
                 width: background.width

--- a/RinUI/components/qmldir
+++ b/RinUI/components/qmldir
@@ -41,6 +41,7 @@ Popup 1.0 DialogsAndFlyouts/Popup.qml
 
 # Layout
 Expander 1.0 Layout/Expander.qml
+RoundedCornerOverlay 1.0 Layout/RoundedCornerOverlay.qml
 
 # Status & Info
 InfoBar 1.0 StatusAndInfo/InfoBar.qml

--- a/RinUI/qmldir
+++ b/RinUI/qmldir
@@ -43,6 +43,7 @@ TeachingTip 1.0 components/DialogsAndFlyouts/TeachingTip.qml
 Expander 1.0 components/Layout/Expander.qml
 SettingExpander 1.0 components/Layout/SettingExpander.qml
 SettingItem 1.0 components/Layout/SettingItem.qml
+RoundedCornerOverlay 1.0 components/Layout/RoundedCornerOverlay.qml
 
 
 # Text

--- a/RinUI/themes/utils.qml
+++ b/RinUI/themes/utils.qml
@@ -30,20 +30,34 @@ QtObject {
     property int animationSpeedMiddle: 450 // 动画速度 (ms)
     property int progressBarAnimationSpeed: 1550 // 进度条动画速度 (ms)
 
-    // HiDPI 缩放因子，用于手动缩放像素值
+    // 当前屏幕 devicePixelRatio（只读诊断用）。
+    // Qt Quick 的宽高 / font.pixelSize 已是逻辑像素，布局中不要再乘 dpiScale。
     readonly property real dpiScale: Screen.devicePixelRatio || 1.0
 
     function loadFontIconIndex() {
         Qt.include(fontIconIndexSource);
     }
 
-    // DPI 感知的像素值缩放
+    // @deprecated 请勿用于布局或字号。Qt Quick 尺寸已是逻辑像素，再乘 dpr 会双重缩放。
+    // 仅保留 API 兼容；行为为恒等映射，并在首次调用时警告。
+    property bool _dpWarned: false
     function dp(value) {
-        return value * dpiScale
+        if (!_dpWarned) {
+            _dpWarned = true
+            console.warn(
+                "[RinUI] Utils.dp() is deprecated: Qt Quick uses logical pixels. "
+                + "Do not multiply layout/font sizes by devicePixelRatio. Returning value as-is."
+            )
+        }
+        return value
     }
 
     Component.onCompleted: {
         console.log("Font Family: " + fontFamily)
-        console.log("DPI Scale Factor: " + dpiScale)
+        console.log("[RinUI] DPI Scale Factor (devicePixelRatio): " + dpiScale)
+        console.log(
+            "[RinUI] HiDPI note: avoid layer+OpacityMask on text containers; "
+            + "PassThrough scale policy is set in RinUI/__init__.py"
+        )
     }
 }

--- a/RinUI/windows/FluentPage.qml
+++ b/RinUI/windows/FluentPage.qml
@@ -1,13 +1,14 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 2.15
-import QtQuick.Window 2.15
-import Qt5Compat.GraphicalEffects  // 图形库
 import "../themes"
 import "../components"
 import "../windows"
 
 // 内容层 / Content Area
+// HiDPI: 禁止对整页启用 layer + OpacityMask。离屏纹理会把文字重光栅化，
+// 导致 4K/高缩放下右侧正文发糊，而侧边栏（无 layer）保持清晰。
+// 圆角视觉由 NavigationView.appLayer 负责；此处仅矩形 clip 滚动区域。
 Page {
     id: fluentPage
     default property alias content: container.data
@@ -23,7 +24,6 @@ Page {
     // StackView.onRemoved: destroy()
     spacing: 14
     property alias contentSpacing: container.spacing
-
 
     // 头部 / Header //
     header: Item {
@@ -87,23 +87,6 @@ Page {
             anchors.horizontalCenter: parent.horizontalCenter
             width: Math.min(fluentPage.width - fluentPage.horizontalPadding * 2, fluentPage.wrapperWidth)  // 24 + 24 的边距
             spacing: fluentPage.spacing
-        }
-    }
-
-    layer.enabled: true
-    layer.textureSize: Qt.size(fluentPage.width * Screen.devicePixelRatio, fluentPage.height * Screen.devicePixelRatio)
-    layer.effect: OpacityMask{
-        maskSource: Rectangle{
-            width: fluentPage.width
-            height: fluentPage.height
-            radius: fluentPage.radius
-
-            Rectangle {
-                anchors.right: parent.right
-                anchors.top: parent.top
-                width: parent.width - Theme.currentTheme.appearance.windowRadius
-                height: Theme.currentTheme.appearance.windowRadius
-            }
         }
     }
 

--- a/RinUI/windows/FluentPage.qml
+++ b/RinUI/windows/FluentPage.qml
@@ -7,8 +7,8 @@ import "../windows"
 
 // 内容层 / Content Area
 // HiDPI: 禁止对整页启用 layer + OpacityMask（会把文字重光栅化导致发糊）。
-// 内容卡片圆角由 NavigationView 的 RoundedCornerOverlay + appLayer 在库层统一处理；
-// 业务页（含 banner）无需再写圆角 mask。此处 Flickable 仅矩形 clip 滚动。
+// 内容区圆角由 NavigationView.RoundedCornerOverlay 库层处理（默认仅左上圆角，
+// 与历史 OpacityMask 形状一致）；业务页无需再写圆角 mask。
 Page {
     id: fluentPage
     default property alias content: container.data

--- a/RinUI/windows/FluentPage.qml
+++ b/RinUI/windows/FluentPage.qml
@@ -6,9 +6,9 @@ import "../components"
 import "../windows"
 
 // 内容层 / Content Area
-// HiDPI: 禁止对整页启用 layer + OpacityMask。离屏纹理会把文字重光栅化，
-// 导致 4K/高缩放下右侧正文发糊，而侧边栏（无 layer）保持清晰。
-// 圆角视觉由 NavigationView.appLayer 负责；此处仅矩形 clip 滚动区域。
+// HiDPI: 禁止对整页启用 layer + OpacityMask（会把文字重光栅化导致发糊）。
+// 内容卡片圆角由 NavigationView 的 RoundedCornerOverlay + appLayer 在库层统一处理；
+// 业务页（含 banner）无需再写圆角 mask。此处 Flickable 仅矩形 clip 滚动。
 Page {
     id: fluentPage
     default property alias content: container.data

--- a/examples/pages/AllSamples.qml
+++ b/examples/pages/AllSamples.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 2.15
+import QtQuick.Window 2.15
 import Qt5Compat.GraphicalEffects  // 图形库
 import RinUI
 import "../assets"
@@ -13,6 +14,7 @@ FluentPage {
     padding: 0
 
     // Banner / 横幅 //
+    // 仅遮罩图片（顶圆角 + 底渐变）；标题在 mask 外直接绘制，保持 HiDPI 清晰
     header: Item {
         width: parent.width
         height: 200
@@ -26,10 +28,21 @@ FluentPage {
             horizontalAlignment: Image.AlignLeft
 
             layer.enabled: true
+            layer.smooth: false
+            layer.mipmap: false
+            layer.textureSize: Qt.size(
+                Math.max(1, Math.ceil(width * Screen.devicePixelRatio)),
+                Math.max(1, Math.ceil(height * Screen.devicePixelRatio))
+            )
             layer.effect: OpacityMask {
                 maskSource: Rectangle {
                     width: banner.width
                     height: banner.height
+                    radius: 0
+                    topLeftRadius: Theme.currentTheme.appearance.windowRadius
+                    topRightRadius: Theme.currentTheme.appearance.windowRadius
+                    bottomLeftRadius: 0
+                    bottomRightRadius: 0
 
                     // 渐变效果
                     gradient: Gradient {

--- a/examples/pages/AllSamples.qml
+++ b/examples/pages/AllSamples.qml
@@ -13,8 +13,7 @@ FluentPage {
     wrapperWidth: width - 42*2
     padding: 0
 
-    // Banner / 横幅 //
-    // 仅遮罩图片（顶圆角 + 底渐变）；标题在 mask 外直接绘制，保持 HiDPI 清晰
+    // Banner / 横幅：仅业务渐变；卡片圆角由 NavigationView 库层裁切
     header: Item {
         width: parent.width
         height: 200
@@ -38,11 +37,6 @@ FluentPage {
                 maskSource: Rectangle {
                     width: banner.width
                     height: banner.height
-                    radius: 0
-                    topLeftRadius: Theme.currentTheme.appearance.windowRadius
-                    topRightRadius: Theme.currentTheme.appearance.windowRadius
-                    bottomLeftRadius: 0
-                    bottomRightRadius: 0
 
                     // 渐变效果
                     gradient: Gradient {

--- a/examples/pages/Home.qml
+++ b/examples/pages/Home.qml
@@ -20,6 +20,7 @@ FluentPage {
         height: 350
         // height: Math.max(window.height * 0.45, 200)
 
+        // 仅遮罩图片：顶圆角贴合 appLayer + 底渐变；标题文字在 mask 外直接绘制（HiDPI 不糊字）
         Image {
             id: bannerSource
             anchors.fill: parent
@@ -34,24 +35,32 @@ FluentPage {
             hideSource: true
             live: true
             visible: false
+            smooth: true
+            // 物理像素纹理，避免高分屏下 banner 被二次采样发糊
+            textureSize: Qt.size(
+                Math.max(1, Math.ceil(bannerSource.width * Screen.devicePixelRatio)),
+                Math.max(1, Math.ceil(bannerSource.height * Screen.devicePixelRatio))
+            )
         }
 
         Item {
             id: bannerBackdrop
             anchors.fill: parent
 
-            // Rectangle {
-            //     anchors.fill: parent
-            //     color: Theme.currentTheme.colors.backgroundColor
-            // }
-
             OpacityMask {
                 id: bannerContent
                 anchors.fill: parent
                 source: bannerTexture
                 maskSource: Rectangle {
+                    id: bannerMask
                     width: bannerContent.width
                     height: bannerContent.height
+                    // 顶圆角与内容卡片一致；底直角接下方内容
+                    radius: 0
+                    topLeftRadius: Theme.currentTheme.appearance.windowRadius
+                    topRightRadius: Theme.currentTheme.appearance.windowRadius
+                    bottomLeftRadius: 0
+                    bottomRightRadius: 0
 
                     gradient: Gradient {
                         GradientStop { position: 0.75; color: "white" }

--- a/examples/pages/Home.qml
+++ b/examples/pages/Home.qml
@@ -20,7 +20,7 @@ FluentPage {
         height: 350
         // height: Math.max(window.height * 0.45, 200)
 
-        // 仅遮罩图片：顶圆角贴合 appLayer + 底渐变；标题文字在 mask 外直接绘制（HiDPI 不糊字）
+        // 仅业务渐变；内容卡片圆角由 NavigationView.RoundedCornerOverlay 库层统一裁切
         Image {
             id: bannerSource
             anchors.fill: parent
@@ -36,7 +36,6 @@ FluentPage {
             live: true
             visible: false
             smooth: true
-            // 物理像素纹理，避免高分屏下 banner 被二次采样发糊
             textureSize: Qt.size(
                 Math.max(1, Math.ceil(bannerSource.width * Screen.devicePixelRatio)),
                 Math.max(1, Math.ceil(bannerSource.height * Screen.devicePixelRatio))
@@ -52,15 +51,8 @@ FluentPage {
                 anchors.fill: parent
                 source: bannerTexture
                 maskSource: Rectangle {
-                    id: bannerMask
                     width: bannerContent.width
                     height: bannerContent.height
-                    // 顶圆角与内容卡片一致；底直角接下方内容
-                    radius: 0
-                    topLeftRadius: Theme.currentTheme.appearance.windowRadius
-                    topRightRadius: Theme.currentTheme.appearance.windowRadius
-                    bottomLeftRadius: 0
-                    bottomRightRadius: 0
 
                     gradient: Gradient {
                         GradientStop { position: 0.75; color: "white" }


### PR DESCRIPTION
- Replace Qt5Compat.GraphicalEffects OpacityMask with QtQuick.Effects MultiEffect
- MultiEffect handles HiDPI scaling internally, no need for layer.textureSize
- Cleaner mask source setup with layer.enabled

#100 问题仍未解决。
close #33 