### PR TITLE
fix(window): stabilize macOS native titlebar layout and dragging

### DIFF
--- a/RinUI/components/Navigation/NavigationBar.qml
+++ b/RinUI/components/Navigation/NavigationBar.qml
@@ -24,7 +24,6 @@ Item {
     property int macControlSpacing: 8
     property int macControlLeftMargin: 20
     property int macDragGap: 12
-    property int macNativeControlExtraInset: useNativeMacControls ? 18 : 0
     property int titleBarHeight: window && window.titleBarHeight !== undefined
         ? window.titleBarHeight
         : Theme.currentTheme.appearance.windowTitleBarHeight
@@ -33,9 +32,18 @@ Item {
             ? 3
             : (closeButtonVisible ? 1 : 0) + (minimizeButtonVisible ? 1 : 0) + (maximizeButtonVisible ? 1 : 0))
         : 0
-    property int macTitleSafeInset: isMacOS && macVisibleControlCount > 0
-        ? macControlLeftMargin + (macVisibleControlCount * macControlSize) + ((macVisibleControlCount - 1) * macControlSpacing) + macDragGap + macNativeControlExtraInset
-        : 0
+    // TitleBar already reserves the native traffic-light gutter when this row
+    // is reparented into titleBarLeadingHost. Only inset when we stay local.
+    property int macTitleSafeInset: {
+        if (!isMacOS || macVisibleControlCount <= 0)
+            return 0
+        if (title.parent === (window && window.titleBarLeadingHost))
+            return 0
+        if (useNativeMacControls && window && window.macSafeLeft > 0)
+            return window.macSafeLeft
+        return macControlLeftMargin + (macVisibleControlCount * macControlSize)
+            + ((macVisibleControlCount - 1) * macControlSpacing) + macDragGap
+    }
 
     // property int currentSubIndex: -1
     property bool titleBarEnabled: true

--- a/RinUI/core/launcher.py
+++ b/RinUI/core/launcher.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 from typing import Union
 
-from PySide6.QtCore import QCoreApplication, QObject, QUrl, QTimer
+from PySide6.QtCore import QCoreApplication, QObject, QUrl
 from PySide6.QtGui import QColor, QIcon
 from PySide6.QtQml import QQmlApplicationEngine
 from PySide6.QtQuick import QQuickWindow
@@ -50,11 +50,6 @@ class RinUIWindow:
             )
         self._mac_objc = None
         self._mac_appkit = None
-        # Fine-tune native macOS traffic-light position.
-        self._mac_traffic_lights_offset_x = 10
-        self._mac_traffic_lights_offset_down = 10
-        self._mac_traffic_lights_retry_interval_ms = 50
-        self._mac_traffic_lights_max_retries = 8
         self.qml_path = qml_path
         self._loaded_root_count = len(self.engine.rootObjects())
         self._initialized = True
@@ -173,7 +168,12 @@ class RinUIWindow:
             window.setProperty("_rinuiTransparentRenderClearInstalled", True)
 
     def _setup_macos_native_window(self) -> None:
-        """Apply macOS native titlebar tweaks for custom title content."""
+        """Hide the system title text while keeping native traffic lights.
+
+        Qt 6.9 flags already expand the client area. AppKit is only used as a
+        fallback to hide the stock title label. Traffic lights stay at the
+        system default position; missing pyobjc must not disable the native frame.
+        """
         if sys.platform != "darwin":
             return
 
@@ -181,8 +181,7 @@ class RinUIWindow:
             import AppKit
             import objc
         except Exception as err:
-            print(f"Cannot enable native macOS titlebar integration: {err}")
-            self._disable_native_mac_frame()
+            print(f"AppKit unavailable, using Qt window flags only: {err}")
             return
 
         self._mac_appkit = AppKit
@@ -201,14 +200,7 @@ class RinUIWindow:
 
     def _on_macos_window_visible_changed(self, window: QQuickWindow, visible: bool) -> None:
         if visible and window.property("useNativeMacFrame"):
-            window.setProperty("_rinuiMacTrafficLightsShiftApplied", False)
-            window.setProperty("_rinuiMacTrafficLightsShiftRetryCount", 0)
             self._apply_macos_window_style(window)
-
-    def _disable_native_mac_frame(self) -> None:
-        for window in self.windows:
-            if window.property("useNativeMacFrame"):
-                window.setProperty("useNativeMacFrame", False)
 
     def _apply_macos_window_style(self, window: QQuickWindow) -> None:
         if not self._mac_objc or not self._mac_appkit:
@@ -220,90 +212,14 @@ class RinUIWindow:
             if not ns_window:
                 return
 
-            # Hide the system title visuals and keep traffic lights in place.
             ns_window.setTitleVisibility_(self._mac_appkit.NSWindowTitleHidden)
             ns_window.setTitlebarAppearsTransparent_(True)
-            ns_window.setMovableByWindowBackground_(False)
             style_mask = int(ns_window.styleMask()) | int(
                 self._mac_appkit.NSWindowStyleMaskFullSizeContentView
             )
             ns_window.setStyleMask_(style_mask)
-            self._schedule_macos_traffic_light_shift(window, retry_count=0)
         except Exception as err:
             print(f"Failed to apply macOS native titlebar style: {err}")
-            window.setProperty("useNativeMacFrame", False)
-
-    def _schedule_macos_traffic_light_shift(
-        self, window: QQuickWindow, retry_count: int
-    ) -> None:
-        if window.property("_rinuiMacTrafficLightsShiftApplied"):
-            return
-
-        moved = self._shift_macos_traffic_lights_once(window)
-        if moved:
-            window.setProperty("_rinuiMacTrafficLightsShiftApplied", True)
-            window.setProperty("_rinuiMacTrafficLightsShiftRetryCount", retry_count)
-            return
-
-        if retry_count >= self._mac_traffic_lights_max_retries:
-            return
-
-        next_retry = retry_count + 1
-        window.setProperty("_rinuiMacTrafficLightsShiftRetryCount", next_retry)
-        QTimer.singleShot(
-            self._mac_traffic_lights_retry_interval_ms,
-            lambda w=window, c=next_retry: self._schedule_macos_traffic_light_shift(
-                w, c
-            ),
-        )
-
-    def _shift_macos_traffic_lights_once(self, window: QQuickWindow) -> bool:
-        if not self._mac_objc or not self._mac_appkit:
-            return False
-
-        try:
-            ns_view = self._mac_objc.objc_object(c_void_p=int(window.winId()))
-            ns_window = ns_view.window() if ns_view else None
-            if not ns_window:
-                return False
-
-            close_button = ns_window.standardWindowButton_(
-                self._mac_appkit.NSWindowCloseButton
-            )
-            minimize_button = ns_window.standardWindowButton_(
-                self._mac_appkit.NSWindowMiniaturizeButton
-            )
-            zoom_button = ns_window.standardWindowButton_(
-                self._mac_appkit.NSWindowZoomButton
-            )
-            buttons = [btn for btn in (close_button, minimize_button, zoom_button) if btn]
-            if not buttons:
-                return False
-
-            # Move the shared container first to preserve native spacing.
-            button_host = close_button.superview() if close_button else buttons[0].superview()
-            if button_host:
-                host_frame = button_host.frame()
-                button_host.setFrameOrigin_(
-                    (
-                        host_frame.origin.x + self._mac_traffic_lights_offset_x,
-                        host_frame.origin.y - self._mac_traffic_lights_offset_down,
-                    )
-                )
-                return True
-
-            for button in buttons:
-                frame = button.frame()
-                button.setFrameOrigin_(
-                    (
-                        frame.origin.x + self._mac_traffic_lights_offset_x,
-                        frame.origin.y - self._mac_traffic_lights_offset_down,
-                    )
-                )
-            return True
-        except Exception as err:
-            print(f"Failed to shift macOS traffic lights: {err}")
-            return False
 
     def setIcon(self, path: Union[str, Path] = None) -> None:
         """

--- a/RinUI/windows/FluentWindow.qml
+++ b/RinUI/windows/FluentWindow.qml
@@ -13,7 +13,9 @@ FluentWindowBase {
     minimumWidth: 400
     minimumHeight: 300
     titleEnabled: false
-    titleBarHeight: useNativeMacFrame ? 36 : Theme.currentTheme.appearance.windowTitleBarHeight
+    titleBarHeight: useNativeMacFrame
+        ? Math.max(Theme.currentTheme.appearance.dialogTitleBarHeight, macSafeTop)
+        : Theme.currentTheme.appearance.windowTitleBarHeight
 
     property alias navigationView: navigationView  // 导航栏
     property alias navigationItems: navigationView.navigationItems  // 导航栏item

--- a/RinUI/windows/FluentWindowBase.qml
+++ b/RinUI/windows/FluentWindowBase.qml
@@ -18,28 +18,52 @@ ApplicationWindow {
     property bool isWindows: Qt.platform.os === "windows"
     // Native traffic lights + single custom titlebar integration on macOS.
     property bool useNativeMacFrame: isMacOS
-    // Fine-tune custom title content baseline to match native traffic lights.
-    property int macNativeContentVerticalOffset: useNativeMacFrame ? -2 : 0
+    property int macNativeContentVerticalOffset: 0
     property int expandedClientAreaHint: typeof Qt.ExpandedClientAreaHint !== "undefined"
         ? Qt.ExpandedClientAreaHint
         : 0
     property int noTitleBarBackgroundHint: typeof Qt.NoTitleBarBackgroundHint !== "undefined"
         ? Qt.NoTitleBarBackgroundHint
         : 0
+    property int macNativeTitleBarFlags: Qt.Window
+        | Qt.CustomizeWindowHint
+        | Qt.WindowTitleHint
+        | Qt.WindowSystemMenuHint
+        | expandedClientAreaHint
+        | noTitleBarBackgroundHint
+    readonly property int macSafeTop: {
+        if (!useNativeMacFrame)
+            return 0
+        if (typeof SafeArea === "undefined" || SafeArea.margins === undefined)
+            return 0
+        return Math.round(SafeArea.margins.top)
+    }
+    readonly property int macSafeLeft: {
+        if (!isMacOS)
+            return 0
+        var left = 0
+        if (typeof SafeArea !== "undefined" && SafeArea.margins !== undefined)
+            left = Math.round(SafeArea.margins.left)
+        if (left > 0)
+            return left + 8
+        if (useNativeMacFrame)
+            return 84
+        return 0
+    }
 
     flags: (useNativeMacFrame
-        ? (Qt.Window
-            | Qt.CustomizeWindowHint
-            | Qt.WindowTitleHint
-            | Qt.WindowSystemMenuHint
-            | Qt.ExpandedClientAreaHint
-            | Qt.NoTitleBarBackgroundHint)
+        ? macNativeTitleBarFlags
         : (Qt.Window | Qt.FramelessWindowHint))
         | Qt.WindowMinimizeButtonHint
         | Qt.WindowMaximizeButtonHint
         | Qt.WindowCloseButtonHint
     color: useNativeMacFrame ? Theme.currentTheme.colors.backgroundColor : "transparent"
+    // ExpandedClientAreaHint would otherwise inset the whole contentItem.
+    // TitleBar applies macSafeLeft itself so the sidebar can stay edge-to-edge.
     topPadding: 0
+    leftPadding: 0
+    rightPadding: 0
+    bottomPadding: 0
     
     Component.onCompleted: {
         if (baseWindow.isWindows) {

--- a/RinUI/windows/TitleBar.qml
+++ b/RinUI/windows/TitleBar.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.12
-import QtQuick.Controls 2.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts
-import QtQuick.Window 2.3
+import QtQuick.Window 2.15
 import "../themes"
 import "../components"
 import "../windows"
@@ -29,11 +29,8 @@ Item {
     property int macDragGap: 12
     // Reserve a small leading no-drag zone for overlay actions (e.g. NavigationView back button).
     property int macLeadingInteractiveWidth: 40
-    // Align custom title content with native traffic lights on macOS.
-    property real macNativeContentVerticalOffset: root.isMacOS && root.useNativeMacControls
-        ? ((root.window && root.window.macNativeContentVerticalOffset !== undefined)
-            ? root.window.macNativeContentVerticalOffset
-            : -2)
+    property real macNativeContentVerticalOffset: root.window && root.window.macNativeContentVerticalOffset !== undefined
+        ? root.window.macNativeContentVerticalOffset
         : 0
     property int macNativeControlCount: root.isMacOS && root.useNativeMacControls ? 3 : 0
     property int macVisibleControlCount: root.showMacCustomControls
@@ -46,6 +43,12 @@ Item {
     property int macLeadingInset: root.isMacOS && macControlOccupyCount > 0
         ? root.macControlLeftMargin + (macControlOccupyCount * root.macControlSize) + ((macControlOccupyCount - 1) * root.macControlSpacing) + root.macDragGap
         : 0
+    property int macSafeLeft: root.window && root.window.macSafeLeft > 0
+        ? root.window.macSafeLeft
+        : root.macLeadingInset
+    property int macContentLeftMargin: root.isMacOS && root.useNativeMacControls
+        ? root.macSafeLeft
+        : (root.isMacOS ? 0 : 4)
     property bool macControlsHovered: root.showMacCustomControls && (
         (macCloseBtn.visible && (macCloseBtn.localHovered || macCloseBtn.localPressed)) ||
         (macMinimizeBtn.visible && (macMinimizeBtn.localHovered || macMinimizeBtn.localPressed)) ||
@@ -84,44 +87,40 @@ Item {
         id:rectBk
         anchors.fill: parent
         color: "transparent"
+    }
 
-        MouseArea {
-            enabled: !root.useNativeMacControls
-            anchors.fill: parent
-            anchors.leftMargin: root.isMacOS
-                ? root.macLeadingInset + root.macLeadingInteractiveWidth
-                : 48
-            anchors.margins: Utils.windowDragArea
-            propagateComposedEvents: true
-            acceptedButtons: Qt.LeftButton
-            property point clickPos: "0,0"
-
-            onPressed: {
-                clickPos = Qt.point(mouseX, mouseY)
-
-                if (Qt.platform.os !== "windows" || !WindowManager._isWinMgrInitialized()) {
-                    return
-                }
-                WindowManager.sendDragWindowEvent(window)
+    // Declared on the title bar itself so empty regions start a system move,
+    // while child controls (back, search, window buttons) keep their handlers.
+    DragHandler {
+        id: titleDragHandler
+        target: null
+        x: root.isMacOS ? root.macSafeLeft : 0
+        width: Math.max(0, root.width - x - (root.isMacOS ? 0 : 48))
+        height: root.height
+        acceptedButtons: Qt.LeftButton
+        grabPermissions: PointerHandler.TakeOverForbidden
+        onActiveChanged: {
+            if (!active || !root.window)
+                return
+            if (root.window.visibility === Window.Maximized
+                    || root.window.visibility === Window.FullScreen)
+                return
+            if (Qt.platform.os === "windows" && WindowManager._isWinMgrInitialized()) {
+                WindowManager.sendDragWindowEvent(root.window)
+                return
             }
-            onDoubleClicked: toggleMaximized()
-            onPositionChanged: (mouse) => {
-                if (window.isMaximized || window.isFullScreen || window.visibility === Window.Maximized) {
-                    return
-                }
-
-                if (Qt.platform.os !== "windows" && WindowManager._isWinMgrInitialized()) {
-                    log("Windows only")
-                    return  // 在win环境使用原生方法拖拽
-                }
-
-                //鼠标偏移量
-                let delta = Qt.point(mouse.x-clickPos.x, mouse.y-clickPos.y)
-
-                window.setX(window.x+delta.x)
-                window.setY(window.y+delta.y)
-            }
+            if (typeof root.window.startSystemMove === "function")
+                root.window.startSystemMove()
         }
+    }
+
+    TapHandler {
+        x: titleDragHandler.x
+        width: titleDragHandler.width
+        height: root.height
+        acceptedButtons: Qt.LeftButton
+        grabPermissions: PointerHandler.TakeOverForbidden
+        onDoubleTapped: root.toggleMaximized()
     }
 
     RowLayout {
@@ -130,7 +129,7 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         anchors.verticalCenterOffset: root.macNativeContentVerticalOffset
         height: parent.height
-        anchors.leftMargin: root.isMacOS ? 0 : 4
+        anchors.leftMargin: root.macContentLeftMargin
         spacing: root.isMacOS ? (root.showMacCustomControls ? 12 : 0) : 48
 
         // macOS traffic-light controls stay on the left side of the title.
@@ -177,7 +176,7 @@ Item {
             visible: root.titleEnabled
             Layout.fillHeight: true
             Layout.preferredWidth: visible ? implicitWidth : 0
-            Layout.leftMargin: root.isMacOS ? (root.useNativeMacControls ? root.macLeadingInset : 0) : 16
+            Layout.leftMargin: root.isMacOS ? 0 : 16
             spacing: 16
 
             //图标

--- a/RinUI/windows/WindowManager.qml
+++ b/RinUI/windows/WindowManager.qml
@@ -29,7 +29,9 @@ Item {
     function toggleMaximizeWindow(window) {
         if (!window) return;
 
-        if (window.visibility === Window.Maximized || window.isMaximized) {
+        if (window.visibility === Window.FullScreen
+                || window.visibility === Window.Maximized
+                || window.isMaximized) {
             window.showNormal();
         } else {
             window.showMaximized();

--- a/RinUI/windows/window/Window.qml
+++ b/RinUI/windows/window/Window.qml
@@ -11,8 +11,7 @@ Window {
     property bool isWindows: Qt.platform.os === "windows"
     // Native traffic lights + single custom titlebar integration on macOS.
     property bool useNativeMacFrame: isMacOS
-    // Fine-tune custom title content baseline to match native traffic lights.
-    property int macNativeContentVerticalOffset: useNativeMacFrame ? -2 : 0
+    property int macNativeContentVerticalOffset: 0
     property int expandedClientAreaHint: typeof Qt.ExpandedClientAreaHint !== "undefined"
         ? Qt.ExpandedClientAreaHint
         : 0
@@ -26,6 +25,25 @@ Window {
         | expandedClientAreaHint
         | noTitleBarBackgroundHint
     property int windowsNativeTitleBarFlags: Qt.Window
+    readonly property int macSafeTop: {
+        if (!useNativeMacFrame)
+            return 0
+        if (typeof SafeArea === "undefined" || SafeArea.margins === undefined)
+            return 0
+        return Math.round(SafeArea.margins.top)
+    }
+    readonly property int macSafeLeft: {
+        if (!isMacOS)
+            return 0
+        var left = 0
+        if (typeof SafeArea !== "undefined" && SafeArea.margins !== undefined)
+            left = Math.round(SafeArea.margins.left)
+        if (left > 0)
+            return left + 8
+        if (useNativeMacFrame)
+            return 84
+        return 0
+    }
 
     flags: (useNativeMacFrame
         ? macNativeTitleBarFlags


### PR DESCRIPTION
Stop shifting traffic lights via AppKit, keep the native frame when pyobjc is missing, and let the custom titlebar use SafeArea plus startSystemMove so content no longer collides with system buttons.

Preview:

<img width="1512" height="912" alt="image" src="https://github.com/user-attachments/assets/a2e5da9a-cf0e-4bf3-9ea2-577a9a2d60da" />

<img width="383" height="256" alt="image" src="https://github.com/user-attachments/assets/e9faa9d4-f4a5-4b98-a739-74934732f16e" />
